### PR TITLE
Codex: #2 [MVP] Implement Design System tokens + reusable UI components (NativeWind)

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,14 +1,22 @@
 import { Tabs } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../../src/theme/ThemeProvider";
+import { allegianceToAccent, themeColors } from "../../src/theme/theme";
 
 export default function TabsLayout() {
+  const { allegiance } = useTheme();
+  const accentColor = allegianceToAccent(allegiance);
+
   return (
     <Tabs
       screenOptions={{
         headerShown: false,
-        tabBarStyle: { backgroundColor: "#0b0f16" },
-        tabBarActiveTintColor: "#5cc8ff",
-        tabBarInactiveTintColor: "#91a4c7",
+        tabBarStyle: {
+          backgroundColor: themeColors.hudSurface,
+          borderTopColor: themeColors.hudLine,
+        },
+        tabBarActiveTintColor: accentColor,
+        tabBarInactiveTintColor: themeColors.secondaryText,
       }}
     >
       <Tabs.Screen

--- a/apps/mobile/app/(tabs)/home/index.tsx
+++ b/apps/mobile/app/(tabs)/home/index.tsx
@@ -1,36 +1,132 @@
-import { router } from "expo-router";
-import { Pressable, StyleSheet, Text } from "react-native";
-import PlaceholderScreen from "../../../src/PlaceholderScreen";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import { Button } from "../../../src/components/Button";
+import { Card } from "../../../src/components/Card";
+import { Chip } from "../../../src/components/Chip";
+import { Badge } from "../../../src/components/Badge";
+import { ScreenHeader } from "../../../src/components/ScreenHeader";
+import { StatCard } from "../../../src/components/StatCard";
+import { Avatar } from "../../../src/components/Avatar";
+import { useTheme } from "../../../src/theme/ThemeProvider";
 
 export default function HomeScreen() {
+  const { allegiance, toggleAllegiance, accentTextClass } = useTheme();
+
   return (
-    <PlaceholderScreen
-      title="Dashboard"
-      description="Placeholder for the Force Collector dashboard."
-    >
-      <Pressable style={styles.button} onPress={() => router.push("/add-figure")}>
-        <Text style={styles.buttonText}>Open Add Figure Modal</Text>
-      </Pressable>
-      <Pressable style={styles.button} onPress={() => router.push("/edit-figure")}>
-        <Text style={styles.buttonText}>Open Edit Figure Modal</Text>
-      </Pressable>
-    </PlaceholderScreen>
+    <View className="flex-1 bg-void">
+      <ScreenHeader
+        title="Design System"
+        subtitle={`Allegiance: ${allegiance.toUpperCase()}`}
+        rightSlot={
+          <Button
+            label="Toggle"
+            variant="ghost"
+            onPress={toggleAllegiance}
+          />
+        }
+      />
+      <ScrollView className="flex-1" contentContainerStyle={styles.content}>
+        <View className="gap-6">
+          <View>
+            <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+              Buttons
+            </Text>
+            <View className="mt-3 gap-3">
+              <Button label="Primary Action" />
+              <Button label="Secondary Action" variant="secondary" />
+              <Button label="Ghost Action" variant="ghost" />
+              <Button label="Loading" loading />
+            </View>
+          </View>
+
+          <View>
+            <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+              Cards & Stats
+            </Text>
+            <View className="mt-3 gap-3">
+              <Card>
+                <Text className="text-sm font-space-semibold text-frost-text">
+                  HUD Card Surface
+                </Text>
+                <Text className="mt-2 text-xs text-secondary-text">
+                  Dark slate surfaces with border lines and cyan accents.
+                </Text>
+              </Card>
+              <View className="flex-row gap-3">
+                <View className="flex-1">
+                  <StatCard label="Total Figures" value="248" helper="+12" />
+                </View>
+                <View className="flex-1">
+                  <StatCard label="Wishlist" value="37" helper="Tracked" />
+                </View>
+              </View>
+            </View>
+          </View>
+
+          <View>
+            <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+              Chips
+            </Text>
+            <View className="mt-3 flex-row flex-wrap gap-2">
+              <Chip label="All" selected />
+              <Chip label="Favorites" />
+              <Chip label="Rare" />
+              <Chip label="Clone Wars" />
+            </View>
+          </View>
+
+          <View>
+            <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+              Badges
+            </Text>
+            <View className="mt-3 flex-row flex-wrap gap-2">
+              <Badge label="Owned" tone="owned" />
+              <Badge label="Wishlist" tone="wishlist" />
+              <Badge label="Exclusive" tone="exclusive" />
+              <Badge label="In Stock" tone="in-stock" />
+              <Badge label="Limited" tone="limited" />
+            </View>
+            <Text className="mt-2 text-[11px] text-muted-text">
+              Status uses icon + text in addition to color.
+            </Text>
+          </View>
+
+          <View>
+            <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+              Avatar
+            </Text>
+            <View className="mt-3 flex-row items-center gap-3">
+              <Avatar size="sm" label="FC" />
+              <Avatar size="md" label="JS" />
+              <Avatar size="lg" label="LS" />
+            </View>
+          </View>
+
+          <View>
+            <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+              Accent Preview
+            </Text>
+            <View className="mt-3 flex-row items-center gap-2 rounded-2xl border border-hud-line/60 bg-raised-surface/70 px-4 py-3">
+              <MaterialIcons
+                name="flash-on"
+                size={18}
+                color={allegiance === "light" ? "#2e86c1" : "#c0392b"}
+              />
+              <Text className={`text-sm font-space-medium ${accentTextClass}`}>
+                Allegiance accent updates instantly.
+              </Text>
+            </View>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  button: {
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    borderRadius: 10,
-    backgroundColor: "#1c2a3d",
-    borderWidth: 1,
-    borderColor: "#2f4566",
-    marginBottom: 12,
-  },
-  buttonText: {
-    color: "#e6f0ff",
-    fontSize: 14,
-    fontWeight: "600",
+  content: {
+    paddingHorizontal: 20,
+    paddingTop: 24,
+    paddingBottom: 40,
   },
 });

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,16 +1,39 @@
+import "../global.css";
+
 import { Stack } from "expo-router";
+import { ThemeProvider } from "../src/theme/ThemeProvider";
+import {
+  useFonts,
+  SpaceGrotesk_400Regular,
+  SpaceGrotesk_500Medium,
+  SpaceGrotesk_600SemiBold,
+  SpaceGrotesk_700Bold,
+} from "@expo-google-fonts/space-grotesk";
 
 export default function RootLayout() {
+  const [fontsLoaded] = useFonts({
+    SpaceGrotesk_400Regular,
+    SpaceGrotesk_500Medium,
+    SpaceGrotesk_600SemiBold,
+    SpaceGrotesk_700Bold,
+  });
+
+  if (!fontsLoaded) {
+    return null;
+  }
+
   return (
-    <Stack>
-      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-      <Stack.Screen
-        name="(modals)"
-        options={{
-          presentation: "modal",
-          headerShown: false,
-        }}
-      />
-    </Stack>
+    <ThemeProvider>
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen
+          name="(modals)"
+          options={{
+            presentation: "modal",
+            headerShown: false,
+          }}
+        />
+      </Stack>
+    </ThemeProvider>
   );
 }

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -2,6 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ["babel-preset-expo"],
-    plugins: ["expo-router/babel"],
+    plugins: ["expo-router/babel", "nativewind/babel"],
   };
 };

--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/mobile/nativewind-env.d.ts
+++ b/apps/mobile/nativewind-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="nativewind/types" />

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,9 +10,11 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo-google-fonts/space-grotesk": "^0.2.3",
     "@expo/vector-icons": "^15.0.3",
     "@react-navigation/native": "^7.1.8",
     "expo": "~54.0.32",
+    "expo-blur": "~14.0.3",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",
     "expo-linking": "~8.0.11",
@@ -28,11 +30,13 @@
     "react-native-screens": "~4.16.0",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.5.1",
+    "nativewind": "^4.0.0",
     "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",
     "react-test-renderer": "19.1.0",
+    "tailwindcss": "^3.4.17",
     "typescript": "~5.9.2"
   }
 }

--- a/apps/mobile/src/PlaceholderScreen.tsx
+++ b/apps/mobile/src/PlaceholderScreen.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren } from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { ScreenHeader } from "./components/ScreenHeader";
 
 interface PlaceholderScreenProps {
   title: string;
@@ -12,33 +13,24 @@ export default function PlaceholderScreen({
   children,
 }: PropsWithChildren<PlaceholderScreenProps>) {
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>{title}</Text>
-      {description ? <Text style={styles.description}>{description}</Text> : null}
-      <View style={styles.content}>{children}</View>
+    <View className="flex-1 bg-void">
+      <ScreenHeader title={title} subtitle="Force Collector" />
+      <ScrollView className="flex-1" contentContainerStyle={styles.content}>
+        {description ? (
+          <Text className="mb-6 text-sm font-space-medium text-secondary-text">
+            {description}
+          </Text>
+        ) : null}
+        <View className="gap-4">{children}</View>
+      </ScrollView>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    paddingHorizontal: 24,
-    paddingTop: 32,
-    backgroundColor: "#0b0f16",
-  },
-  title: {
-    color: "#e6f0ff",
-    fontSize: 24,
-    fontWeight: "700",
-  },
-  description: {
-    color: "#91a4c7",
-    marginTop: 8,
-    fontSize: 14,
-    lineHeight: 20,
-  },
   content: {
-    marginTop: 24,
+    paddingHorizontal: 20,
+    paddingTop: 24,
+    paddingBottom: 32,
   },
 });

--- a/apps/mobile/src/components/Avatar.tsx
+++ b/apps/mobile/src/components/Avatar.tsx
@@ -1,0 +1,29 @@
+import { Text, View } from "react-native";
+import { cx } from "../utils/cx";
+
+type AvatarProps = {
+  label?: string;
+  size?: "sm" | "md" | "lg";
+};
+
+const sizeClasses: Record<NonNullable<AvatarProps["size"]>, string> = {
+  sm: "h-8 w-8",
+  md: "h-12 w-12",
+  lg: "h-16 w-16",
+};
+
+export function Avatar({ label = "FC", size = "md" }: AvatarProps) {
+  return (
+    <View
+      className={cx(
+        "items-center justify-center rounded-full border border-hud-line/70 bg-raised-surface",
+        sizeClasses[size]
+      )}
+    >
+      <Text className="text-xs font-space-bold uppercase tracking-widest text-nav-tint">
+        {label}
+      </Text>
+    </View>
+  );
+}
+

--- a/apps/mobile/src/components/Badge.tsx
+++ b/apps/mobile/src/components/Badge.tsx
@@ -1,0 +1,92 @@
+import { MaterialIcons } from "@expo/vector-icons";
+import { Text, View } from "react-native";
+import { useTheme } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+type BadgeTone =
+  | "owned"
+  | "wishlist"
+  | "exclusive"
+  | "in-stock"
+  | "limited"
+  | "neutral";
+
+type BadgeProps = {
+  label: string;
+  tone?: BadgeTone;
+  iconName?: keyof typeof MaterialIcons.glyphMap;
+};
+
+const toneConfig: Record<
+  BadgeTone,
+  {
+    icon: keyof typeof MaterialIcons.glyphMap;
+    className: string;
+    textClassName: string;
+    iconColor: string;
+  }
+> = {
+  owned: {
+    icon: "verified",
+    className: "bg-bright-cyan/15",
+    textClassName: "text-bright-cyan",
+    iconColor: "#22d3ee",
+  },
+  wishlist: {
+    icon: "favorite-border",
+    className: "bg-action-blue/15",
+    textClassName: "text-action-blue",
+    iconColor: "#3b82f6",
+  },
+  exclusive: {
+    icon: "star-border",
+    className: "bg-laser-cyan/15",
+    textClassName: "text-laser-cyan",
+    iconColor: "#00e5ff",
+  },
+  "in-stock": {
+    icon: "inventory-2",
+    className: "bg-electric-cyan/15",
+    textClassName: "text-electric-cyan",
+    iconColor: "#06b6d4",
+  },
+  limited: {
+    icon: "bolt",
+    className: "bg-royal-blue/15",
+    textClassName: "text-royal-blue",
+    iconColor: "#2563eb",
+  },
+  neutral: {
+    icon: "info-outline",
+    className: "bg-raised-surface/60",
+    textClassName: "text-secondary-text",
+    iconColor: "#94a3b8",
+  },
+};
+
+export function Badge({ label, tone = "neutral", iconName }: BadgeProps) {
+  const { accentBorderClass } = useTheme();
+  const config = toneConfig[tone];
+  const icon = iconName ?? config.icon;
+
+  return (
+    <View
+      className={cx(
+        "flex-row items-center gap-1 rounded-full border px-2.5 py-1",
+        accentBorderClass,
+        config.className
+      )}
+      accessibilityLabel={`${label} badge`}
+    >
+      <MaterialIcons name={icon} size={12} color={config.iconColor} />
+      <Text
+        className={cx(
+          "text-[10px] font-space-semibold uppercase tracking-widest",
+          config.textClassName
+        )}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/Button.tsx
+++ b/apps/mobile/src/components/Button.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from "react";
+import { ActivityIndicator, Pressable, Text } from "react-native";
+import { useTheme } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+type ButtonVariant = "primary" | "secondary" | "ghost";
+
+type ButtonProps = {
+  label: string;
+  variant?: ButtonVariant;
+  loading?: boolean;
+  disabled?: boolean;
+  onPress?: () => void;
+  icon?: ReactNode;
+};
+
+export function Button({
+  label,
+  variant = "primary",
+  loading = false,
+  disabled = false,
+  onPress,
+  icon,
+}: ButtonProps) {
+  const {
+    accentBorderClass,
+    accentBgClass,
+    accentSoftBgClass,
+    accentTextClass,
+  } = useTheme();
+  const isDisabled = disabled || loading;
+  const variantClasses =
+    variant === "primary"
+      ? cx("bg-royal-blue", accentBorderClass, "border")
+      : variant === "secondary"
+        ? cx("bg-hud-surface", accentBorderClass, "border")
+        : cx("bg-transparent", accentBorderClass, "border");
+  const textClasses =
+    variant === "ghost"
+      ? cx(accentTextClass, "uppercase tracking-widest")
+      : "text-frost-text uppercase tracking-widest";
+
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={isDisabled}
+      className={cx(
+        "flex-row items-center justify-center gap-2 rounded-xl px-4 py-3",
+        "shadow-lg",
+        variant === "ghost" && accentSoftBgClass,
+        isDisabled && "opacity-60",
+        variantClasses
+      )}
+    >
+      {loading ? (
+        <ActivityIndicator size="small" color="#f8fafc" />
+      ) : (
+        icon
+      )}
+      <Text className={cx("text-xs font-space-semibold", textClasses)}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/Card.tsx
+++ b/apps/mobile/src/components/Card.tsx
@@ -1,0 +1,21 @@
+import type { PropsWithChildren } from "react";
+import { View } from "react-native";
+import { cx } from "../utils/cx";
+
+type CardProps = PropsWithChildren<{
+  className?: string;
+}>;
+
+export function Card({ children, className }: CardProps) {
+  return (
+    <View
+      className={cx(
+        "rounded-2xl border border-hud-line/60 bg-hud-surface p-4",
+        className
+      )}
+    >
+      {children}
+    </View>
+  );
+}
+

--- a/apps/mobile/src/components/Chip.tsx
+++ b/apps/mobile/src/components/Chip.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import { Pressable, Text } from "react-native";
+import { useTheme } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+type ChipProps = {
+  label: string;
+  selected?: boolean;
+  onPress?: () => void;
+  icon?: ReactNode;
+};
+
+export function Chip({ label, selected = false, onPress, icon }: ChipProps) {
+  const { accentBorderClass, accentSoftBgClass, accentTextClass } = useTheme();
+
+  return (
+    <Pressable
+      onPress={onPress}
+      className={cx(
+        "flex-row items-center gap-2 rounded-full border px-3 py-1.5",
+        selected ? accentSoftBgClass : "bg-raised-surface/60",
+        selected ? accentBorderClass : "border-hud-line/60"
+      )}
+    >
+      {icon}
+      <Text
+        className={cx(
+          "text-[10px] font-space-semibold uppercase tracking-widest",
+          selected ? accentTextClass : "text-secondary-text"
+        )}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+

--- a/apps/mobile/src/components/ScreenHeader.tsx
+++ b/apps/mobile/src/components/ScreenHeader.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { BlurView } from "expo-blur";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useTheme } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+type ScreenHeaderProps = {
+  title: string;
+  subtitle?: string;
+  rightSlot?: ReactNode;
+  variant?: "default" | "blur";
+};
+
+export function ScreenHeader({
+  title,
+  subtitle,
+  rightSlot,
+  variant = "blur",
+}: ScreenHeaderProps) {
+  const { accentTextClass } = useTheme();
+  return (
+    <SafeAreaView edges={["top"]} className="bg-void">
+      {variant === "blur" ? (
+        <BlurView intensity={40} tint="dark" style={styles.blurContainer}>
+          <View className="flex-row items-start justify-between">
+            <View className="flex-1 pr-4">
+              <Text className="text-lg font-space-bold uppercase tracking-wide text-frost-text">
+                {title}
+              </Text>
+              {subtitle ? (
+                <Text
+                  className={cx(
+                    "text-xs font-space-medium uppercase tracking-widest",
+                    accentTextClass
+                  )}
+                >
+                  {subtitle}
+                </Text>
+              ) : null}
+            </View>
+            {rightSlot ? <View className="pt-1">{rightSlot}</View> : null}
+          </View>
+        </BlurView>
+      ) : (
+        <View className="border-b border-hud-line/60 bg-void px-4 py-4">
+          <View className="flex-row items-start justify-between">
+            <View className="flex-1 pr-4">
+              <Text className="text-lg font-space-bold uppercase tracking-wide text-frost-text">
+                {title}
+              </Text>
+              {subtitle ? (
+                <Text
+                  className={cx(
+                    "text-xs font-space-medium uppercase tracking-widest",
+                    accentTextClass
+                  )}
+                >
+                  {subtitle}
+                </Text>
+              ) : null}
+            </View>
+            {rightSlot ? <View className="pt-1">{rightSlot}</View> : null}
+          </View>
+        </View>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  blurContainer: {
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(30,58,138,0.6)",
+    backgroundColor: "rgba(2,6,23,0.7)",
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+  },
+});

--- a/apps/mobile/src/components/StatCard.tsx
+++ b/apps/mobile/src/components/StatCard.tsx
@@ -1,0 +1,38 @@
+import { Text, View } from "react-native";
+import { Card } from "./Card";
+import { useTheme } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+type StatCardProps = {
+  label: string;
+  value: string;
+  helper?: string;
+};
+
+export function StatCard({ label, value, helper }: StatCardProps) {
+  const { accentTextClass } = useTheme();
+
+  return (
+    <Card className="gap-2">
+      <Text className="text-[10px] font-space-semibold uppercase tracking-widest text-secondary-text">
+        {label}
+      </Text>
+      <View className="flex-row items-end justify-between">
+        <Text
+          className={cx(
+            "text-2xl font-space-bold tracking-tight",
+            accentTextClass
+          )}
+        >
+          {value}
+        </Text>
+        {helper ? (
+          <Text className="text-xs font-space-medium text-muted-text">
+            {helper}
+          </Text>
+        ) : null}
+      </View>
+    </Card>
+  );
+}
+

--- a/apps/mobile/src/theme/ThemeProvider.tsx
+++ b/apps/mobile/src/theme/ThemeProvider.tsx
@@ -1,0 +1,43 @@
+import type { PropsWithChildren } from "react";
+import { createContext, useContext, useMemo, useState } from "react";
+import type { Allegiance } from "./theme";
+
+type ThemeContextValue = {
+  allegiance: Allegiance;
+  setAllegiance: (next: Allegiance) => void;
+  toggleAllegiance: () => void;
+  accentTextClass: string;
+  accentBorderClass: string;
+  accentBgClass: string;
+  accentSoftBgClass: string;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: PropsWithChildren) {
+  const [allegiance, setAllegiance] = useState<Allegiance>("light");
+
+  const value = useMemo(() => {
+    const isLight = allegiance === "light";
+    return {
+      allegiance,
+      setAllegiance,
+      toggleAllegiance: () =>
+        setAllegiance((prev) => (prev === "light" ? "dark" : "light")),
+      accentTextClass: isLight ? "text-saber-blue" : "text-saber-red",
+      accentBorderClass: isLight ? "border-saber-blue" : "border-saber-red",
+      accentBgClass: isLight ? "bg-saber-blue" : "bg-saber-red",
+      accentSoftBgClass: isLight ? "bg-saber-blue/15" : "bg-saber-red/15",
+    };
+  }, [allegiance]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within ThemeProvider.");
+  }
+  return context;
+}

--- a/apps/mobile/src/theme/theme.ts
+++ b/apps/mobile/src/theme/theme.ts
@@ -1,0 +1,22 @@
+export type Allegiance = "light" | "dark";
+
+export const themeColors = {
+  void: "#020617",
+  hudSurface: "#0f172a",
+  raisedSurface: "#1e293b",
+  frostText: "#f8fafc",
+  mutedText: "#64748b",
+  secondaryText: "#94a3b8",
+  navTint: "#bae6fd",
+  hudLine: "#1e3a8a",
+  saberBlue: "#2e86c1",
+  saberRed: "#c0392b",
+  actionBlue: "#3b82f6",
+  royalBlue: "#2563eb",
+  brightCyan: "#22d3ee",
+  electricCyan: "#06b6d4",
+};
+
+export const allegianceToAccent = (allegiance: Allegiance) =>
+  allegiance === "light" ? themeColors.saberBlue : themeColors.saberRed;
+

--- a/apps/mobile/src/utils/cx.ts
+++ b/apps/mobile/src/utils/cx.ts
@@ -1,0 +1,2 @@
+export const cx = (...values: Array<string | false | null | undefined>) =>
+  values.filter(Boolean).join(" ");

--- a/apps/mobile/tailwind.config.js
+++ b/apps/mobile/tailwind.config.js
@@ -1,0 +1,41 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        "electric-cyan": "#06b6d4",
+        "laser-cyan": "#00e5ff",
+        "bright-cyan": "#22d3ee",
+        "royal-blue": "#2563eb",
+        "action-blue": "#3b82f6",
+        "deep-blue": "#1d4ed8",
+        "scan-blue": "#2979ff",
+        void: "#020617",
+        "hud-surface": "#0f172a",
+        "raised-surface": "#1e293b",
+        "scanner-ink": "#060b14",
+        "camera-deep": "#050a14",
+        "true-black": "#050505",
+        "overlay-ink": "#02040a",
+        "profile-panel": "#1a2234",
+        "profile-nav": "#151b2b",
+        "frost-text": "#f8fafc",
+        "muted-text": "#64748b",
+        "secondary-text": "#94a3b8",
+        "nav-tint": "#bae6fd",
+        "hud-line": "#1e3a8a",
+        "saber-blue": "#2e86c1",
+        "saber-red": "#c0392b",
+        "danger-red": "#dc2626",
+      },
+      fontFamily: {
+        space: ["SpaceGrotesk_400Regular", "System"],
+        "space-medium": ["SpaceGrotesk_500Medium", "System"],
+        "space-semibold": ["SpaceGrotesk_600SemiBold", "System"],
+        "space-bold": ["SpaceGrotesk_700Bold", "System"],
+      },
+    },
+  },
+  plugins: [],
+};

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
-    "types": ["expo-router/types"]
+    "types": ["expo-router/types", "nativewind/types"]
   }
 }


### PR DESCRIPTION
Closes #2

Issue: https://github.com/jayvicsanantonio/force-collector/issues/2
Run: https://github.com/jayvicsanantonio/force-collector/actions/runs/21730358738

<details>
<summary>Codex summary</summary>

Implemented NativeWind + design tokens, added a centralized Allegiance theme provider, and built the required reusable HUD components. The Home tab is now a kitchen‑sink screen showing all component states (including loading buttons and badge status with icon + text), and the tab bar accent updates instantly when toggling Allegiance.

**What changed**
- Added NativeWind + Tailwind config and Force Collector palette tokens, plus global styles and typing support.
- Implemented theme context for Allegiance accent switching and wired it into tabs and components.
- Built reusable UI components: Button, Card, Chip, Badge, ScreenHeader (blur/default), StatCard, Avatar.
- Reworked placeholder screens to use the new header + HUD layout and converted Home into the kitchen‑sink demo.

**How to test (commands)**
1) `cd apps/mobile`  
2) `npm install`  
3) `npm run start`  

**Limitations / follow-ups**
- I didn’t run tests here. The repo doesn’t include UI tests yet; consider adding snapshot or screen-level tests once a test runner is in place.
- Blur header uses `expo-blur`; if you want a no‑native‑module fallback for web, we can add a conditional variant.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched a comprehensive design system with new reusable UI components (buttons, cards, chips, badges, avatars, and stat cards).
  * Added theme support with light and dark mode variants and dynamic accent colors.
  * Redesigned home screen to showcase design system components.
  * Updated tab bar with theme-aware colors and styling.
  * Introduced Space Grotesk typography family for improved visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->