### PR TITLE
chore(actions): run Codex once daily at 7am PT

### DIFF
--- a/.github/workflows/codex-scheduled-issue-pr.yml
+++ b/.github/workflows/codex-scheduled-issue-pr.yml
@@ -7,9 +7,6 @@ on:
     # IMPORTANT: scheduled runs can be delayed by minutes/hours, so we must NOT gate on "current local hour".
     # Instead, we gate on the cron string that triggered the run: github.event.schedule.
     # - 07:00 PT == 15:00 UTC (PST) / 14:00 UTC (PDT)
-    # - 19:00 PT == 03:00 UTC (PST) / 02:00 UTC (PDT)
-    - cron: '0 2 * * *'  # 19:00 PDT
-    - cron: '0 3 * * *'  # 19:00 PST
     - cron: '0 14 * * *' # 07:00 PDT
     - cron: '0 15 * * *' # 07:00 PST
   workflow_dispatch: {}
@@ -27,7 +24,7 @@ jobs:
   codex:
     runs-on: ubuntu-latest
     steps:
-      - name: Guard (run only at 07:00/19:00 PT)
+      - name: Guard (run only at 07:00 PT)
         id: guard
         shell: bash
         run: |
@@ -43,13 +40,13 @@ jobs:
 
           allow="false"
           if [[ "$pt_offset" == "-0800" ]]; then
-            # PST: 07:00 PT == 15:00 UTC, 19:00 PT == 03:00 UTC
-            if [[ "$schedule" == "0 15 * * *" || "$schedule" == "0 3 * * *" ]]; then
+            # PST: 07:00 PT == 15:00 UTC
+            if [[ "$schedule" == "0 15 * * *" ]]; then
               allow="true"
             fi
           elif [[ "$pt_offset" == "-0700" ]]; then
-            # PDT: 07:00 PT == 14:00 UTC, 19:00 PT == 02:00 UTC
-            if [[ "$schedule" == "0 14 * * *" || "$schedule" == "0 2 * * *" ]]; then
+            # PDT: 07:00 PT == 14:00 UTC
+            if [[ "$schedule" == "0 14 * * *" ]]; then
               allow="true"
             fi
           fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified automated workflow scheduling to run once daily (07:00 PT) instead of twice daily, reducing the frequency of scheduled automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->