### PR TITLE
Codex: #8 [MVP] Auth + session management (Sign in/up) + Splash routing + Sign out

### DIFF
--- a/apps/mobile/app/(auth)/_layout.tsx
+++ b/apps/mobile/app/(auth)/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from "expo-router";
+
+export default function AuthLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/apps/mobile/app/(auth)/create-account.tsx
+++ b/apps/mobile/app/(auth)/create-account.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from "react";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { router } from "expo-router";
+import { Button } from "../../src/components/Button";
+import { AuthScreenShell } from "../../src/auth/AuthScreenShell";
+import { useAuth } from "../../src/auth/AuthProvider";
+import { track } from "../../src/observability";
+
+export default function CreateAccountScreen() {
+  const { status, signUpWithEmail } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (status === "signedIn") {
+      router.replace("/home");
+    }
+  }, [status]);
+
+  const handleCreateAccount = async () => {
+    setError(null);
+    setNotice(null);
+    setLoading(true);
+    try {
+      await signUpWithEmail(email.trim(), password);
+      track("auth_sign_up_success");
+      setNotice("Check your inbox to confirm your account.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to create account.");
+      track("auth_sign_up_failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthScreenShell
+      title="Create Account"
+      subtitle="Start tracking your collection across devices."
+      footer={
+        <View className="flex-row items-center justify-between">
+          <Text className="text-xs text-secondary-text">Already have an account?</Text>
+          <Pressable
+            onPress={() => {
+              track("auth_sign_in_from_create_account");
+              router.replace("/(auth)/sign-in");
+            }}
+          >
+            <Text className="text-xs font-space-semibold uppercase tracking-widest text-electric-cyan">
+              Sign In
+            </Text>
+          </Pressable>
+        </View>
+      }
+    >
+      <View style={styles.card}>
+        <Text style={styles.label}>Email</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="pilot@rebellion.io"
+          placeholderTextColor="#64748b"
+          value={email}
+          autoCapitalize="none"
+          keyboardType="email-address"
+          onChangeText={setEmail}
+        />
+        <Text style={[styles.label, styles.spacingTop]}>Password</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Create a secure password"
+          placeholderTextColor="#64748b"
+          value={password}
+          secureTextEntry
+          onChangeText={setPassword}
+        />
+        {error ? <Text style={styles.errorText}>{error}</Text> : null}
+        {notice ? <Text style={styles.noticeText}>{notice}</Text> : null}
+        <Button
+          label="Create Account"
+          loading={loading}
+          onPress={handleCreateAccount}
+        />
+      </View>
+    </AuthScreenShell>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 16,
+    borderRadius: 16,
+    backgroundColor: "#0f172a",
+    borderWidth: 1,
+    borderColor: "rgba(30,58,138,0.6)",
+    gap: 12,
+  },
+  label: {
+    fontSize: 11,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    color: "#94a3b8",
+    fontWeight: "600",
+  },
+  spacingTop: {
+    marginTop: 4,
+  },
+  input: {
+    backgroundColor: "#1e293b",
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    color: "#f8fafc",
+    fontSize: 14,
+  },
+  errorText: {
+    color: "#dc2626",
+    fontSize: 12,
+  },
+  noticeText: {
+    color: "#22d3ee",
+    fontSize: 12,
+  },
+});

--- a/apps/mobile/app/(auth)/forgot-password.tsx
+++ b/apps/mobile/app/(auth)/forgot-password.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { router } from "expo-router";
+import { Button } from "../../src/components/Button";
+import { AuthScreenShell } from "../../src/auth/AuthScreenShell";
+import { useAuth } from "../../src/auth/AuthProvider";
+import { track } from "../../src/observability";
+
+export default function ForgotPasswordScreen() {
+  const { requestPasswordReset } = useAuth();
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const handleReset = async () => {
+    setError(null);
+    setNotice(null);
+    setLoading(true);
+    try {
+      await requestPasswordReset(email.trim());
+      track("auth_password_reset_requested");
+      setNotice("Password reset email sent.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to send reset email.");
+      track("auth_password_reset_failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthScreenShell
+      title="Reset Password"
+      subtitle="We'll send a secure reset link to your email."
+      footer={
+        <View className="flex-row items-center justify-between">
+          <Text className="text-xs text-secondary-text">Remembered it?</Text>
+          <Pressable
+            onPress={() => {
+              track("auth_sign_in_from_reset");
+              router.replace("/(auth)/sign-in");
+            }}
+          >
+            <Text className="text-xs font-space-semibold uppercase tracking-widest text-electric-cyan">
+              Sign In
+            </Text>
+          </Pressable>
+        </View>
+      }
+    >
+      <View style={styles.card}>
+        <Text style={styles.label}>Email</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="pilot@rebellion.io"
+          placeholderTextColor="#64748b"
+          value={email}
+          autoCapitalize="none"
+          keyboardType="email-address"
+          onChangeText={setEmail}
+        />
+        {error ? <Text style={styles.errorText}>{error}</Text> : null}
+        {notice ? <Text style={styles.noticeText}>{notice}</Text> : null}
+        <Button label="Send Reset Link" loading={loading} onPress={handleReset} />
+      </View>
+    </AuthScreenShell>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 16,
+    borderRadius: 16,
+    backgroundColor: "#0f172a",
+    borderWidth: 1,
+    borderColor: "rgba(30,58,138,0.6)",
+    gap: 12,
+  },
+  label: {
+    fontSize: 11,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    color: "#94a3b8",
+    fontWeight: "600",
+  },
+  input: {
+    backgroundColor: "#1e293b",
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    color: "#f8fafc",
+    fontSize: 14,
+  },
+  errorText: {
+    color: "#dc2626",
+    fontSize: 12,
+  },
+  noticeText: {
+    color: "#22d3ee",
+    fontSize: 12,
+  },
+});

--- a/apps/mobile/app/(auth)/sign-in.tsx
+++ b/apps/mobile/app/(auth)/sign-in.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from "react";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { router } from "expo-router";
+import { Button } from "../../src/components/Button";
+import { AuthScreenShell } from "../../src/auth/AuthScreenShell";
+import { useAuth } from "../../src/auth/AuthProvider";
+import { track } from "../../src/observability";
+
+export default function SignInScreen() {
+  const { status, signInWithEmail } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (status === "signedIn") {
+      router.replace("/home");
+    }
+  }, [status]);
+
+  const handleSignIn = async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      await signInWithEmail(email.trim(), password);
+      track("auth_sign_in_success");
+      router.replace("/home");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to sign in.");
+      track("auth_sign_in_failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthScreenShell
+      title="Sign In"
+      subtitle="Access your collection and synced data."
+      footer={
+        <View className="flex-row items-center justify-between">
+          <Text className="text-xs text-secondary-text">New here?</Text>
+          <Pressable
+            onPress={() => {
+              track("auth_create_account_from_sign_in");
+              router.replace("/(auth)/create-account");
+            }}
+          >
+            <Text className="text-xs font-space-semibold uppercase tracking-widest text-electric-cyan">
+              Create Account
+            </Text>
+          </Pressable>
+        </View>
+      }
+    >
+      <View style={styles.card}>
+        <Text style={styles.label}>Email</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="pilot@rebellion.io"
+          placeholderTextColor="#64748b"
+          value={email}
+          autoCapitalize="none"
+          keyboardType="email-address"
+          onChangeText={setEmail}
+        />
+        <Text style={[styles.label, styles.spacingTop]}>Password</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="••••••••"
+          placeholderTextColor="#64748b"
+          value={password}
+          secureTextEntry
+          onChangeText={setPassword}
+        />
+        {error ? <Text style={styles.errorText}>{error}</Text> : null}
+        <Button label="Sign In" loading={loading} onPress={handleSignIn} />
+        <Pressable
+          style={styles.linkRow}
+          onPress={() => {
+            track("auth_forgot_password_from_sign_in");
+            router.push("/(auth)/forgot-password");
+          }}
+        >
+          <Text style={styles.linkText}>Forgot password?</Text>
+        </Pressable>
+      </View>
+    </AuthScreenShell>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 16,
+    borderRadius: 16,
+    backgroundColor: "#0f172a",
+    borderWidth: 1,
+    borderColor: "rgba(30,58,138,0.6)",
+    gap: 12,
+  },
+  label: {
+    fontSize: 11,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    color: "#94a3b8",
+    fontWeight: "600",
+  },
+  spacingTop: {
+    marginTop: 4,
+  },
+  input: {
+    backgroundColor: "#1e293b",
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    color: "#f8fafc",
+    fontSize: 14,
+  },
+  errorText: {
+    color: "#dc2626",
+    fontSize: 12,
+  },
+  linkRow: {
+    alignItems: "center",
+  },
+  linkText: {
+    color: "#22d3ee",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,11 +1,24 @@
-import { Tabs } from "expo-router";
+import { Tabs, router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
+import { useEffect } from "react";
+import { useAuth } from "../../src/auth/AuthProvider";
 import { useTheme } from "../../src/theme/ThemeProvider";
 import { allegianceToAccent, themeColors } from "../../src/theme/theme";
 
 export default function TabsLayout() {
+  const { status } = useAuth();
   const { allegiance } = useTheme();
   const accentColor = allegianceToAccent(allegiance);
+
+  useEffect(() => {
+    if (status === "signedOut") {
+      router.replace("/");
+    }
+  }, [status]);
+
+  if (status === "checking") {
+    return null;
+  }
 
   return (
     <Tabs

--- a/apps/mobile/app/(tabs)/profile/settings.tsx
+++ b/apps/mobile/app/(tabs)/profile/settings.tsx
@@ -1,4 +1,5 @@
 import { Pressable, StyleSheet, Text, View } from "react-native";
+import { router } from "expo-router";
 import PlaceholderScreen from "../../../src/PlaceholderScreen";
 import { signOutAndClearUserData } from "../../../src/offline/session";
 import { captureError, track } from "../../../src/observability";
@@ -20,6 +21,7 @@ export default function SettingsScreen() {
             track("profile_sign_out");
             try {
               await signOutAndClearUserData();
+              router.replace("/");
             } catch (error) {
               captureError(error, { source: "settings", action: "sign_out" });
             }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "../src/theme/ThemeProvider";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "../src/api/queryClient";
 import { OfflineProvider } from "../src/offline/OfflineProvider";
+import { AuthProvider } from "../src/auth/AuthProvider";
 import { useEffect } from "react";
 import { initObservability, wrapWithObservability } from "../src/observability";
 import {
@@ -33,20 +34,24 @@ function RootLayout() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <OfflineProvider>
-        <ThemeProvider>
-          <Stack>
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-            <Stack.Screen
-              name="(modals)"
-              options={{
-                presentation: "modal",
-                headerShown: false,
-              }}
-            />
-          </Stack>
-        </ThemeProvider>
-      </OfflineProvider>
+      <AuthProvider>
+        <OfflineProvider>
+          <ThemeProvider>
+            <Stack>
+              <Stack.Screen name="index" options={{ headerShown: false }} />
+              <Stack.Screen name="(auth)" options={{ headerShown: false }} />
+              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+              <Stack.Screen
+                name="(modals)"
+                options={{
+                  presentation: "modal",
+                  headerShown: false,
+                }}
+              />
+            </Stack>
+          </ThemeProvider>
+        </OfflineProvider>
+      </AuthProvider>
     </QueryClientProvider>
   );
 }

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,31 +1,51 @@
 import { router } from "expo-router";
 import { useEffect } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from "react-native";
+import { authConfig } from "../src/auth/config";
+import { useAuth } from "../src/auth/AuthProvider";
 import { track } from "../src/observability";
 
 export default function Index() {
+  const { status } = useAuth();
+
   useEffect(() => {
     track("splash_viewed");
   }, []);
+
+  useEffect(() => {
+    if (status === "signedIn" && authConfig.bypassSplashWhenSignedIn) {
+      router.replace("/home");
+    }
+  }, [status]);
+
+  const isChecking = status === "checking";
 
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Force Collector</Text>
       <Text style={styles.subtitle}>Welcome to the collection hub.</Text>
+      {isChecking ? (
+        <View style={styles.loadingRow}>
+          <ActivityIndicator size="small" color="#06b6d4" />
+          <Text style={styles.loadingText}>Checking session...</Text>
+        </View>
+      ) : null}
       <Pressable
-        style={styles.primaryButton}
+        style={[styles.primaryButton, isChecking && styles.disabledButton]}
+        disabled={isChecking}
         onPress={() => {
           track("splash_get_started_tapped");
-          router.replace("/home");
+          router.replace("/(auth)/create-account");
         }}
       >
         <Text style={styles.primaryButtonText}>Get Started</Text>
       </Pressable>
       <Pressable
-        style={styles.secondaryButton}
+        style={[styles.secondaryButton, isChecking && styles.disabledButton]}
+        disabled={isChecking}
         onPress={() => {
           track("splash_access_existing_tapped");
-          router.replace("/home");
+          router.replace("/(auth)/sign-in");
         }}
       >
         <Text style={styles.secondaryButtonText}>Access Existing Data</Text>
@@ -51,6 +71,16 @@ const styles = StyleSheet.create({
     color: "#91a4c7",
     fontSize: 14,
     lineHeight: 20,
+  },
+  loadingRow: {
+    marginTop: 20,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  loadingText: {
+    color: "#91a4c7",
+    fontSize: 12,
   },
   primaryButton: {
     marginTop: 24,
@@ -81,5 +111,8 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: "600",
     textAlign: "center",
+  },
+  disabledButton: {
+    opacity: 0.6,
   },
 });

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -37,6 +37,7 @@
     "react-native-worklets": "0.5.1",
     "nativewind": "^4.0.0",
     "dotenv": "^16.4.5",
+    "@supabase/supabase-js": "^2.49.1",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/apps/mobile/src/auth/AuthProvider.tsx
+++ b/apps/mobile/src/auth/AuthProvider.tsx
@@ -1,0 +1,144 @@
+import type { PropsWithChildren } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import type { Session, User } from "@supabase/supabase-js";
+import { supabase } from "./supabase";
+import { env } from "../env";
+import { clearAuthToken, setAuthToken } from "../api/auth";
+import { setActiveUserId } from "../offline/db";
+import { signOutAndClearUserData } from "../offline/session";
+
+type AuthStatus = "checking" | "signedOut" | "signedIn";
+
+type AuthContextValue = {
+  status: AuthStatus;
+  session: Session | null;
+  user: User | null;
+  signInWithEmail: (email: string, password: string) => Promise<void>;
+  signUpWithEmail: (email: string, password: string) => Promise<void>;
+  requestPasswordReset: (email: string) => Promise<void>;
+  signOut: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+function assertAuthConfigured() {
+  if (!env.SUPABASE_URL || !env.SUPABASE_ANON_KEY) {
+    throw new Error("Supabase auth is not configured.");
+  }
+}
+
+export function AuthProvider({ children }: PropsWithChildren) {
+  const [status, setStatus] = useState<AuthStatus>("checking");
+  const [session, setSession] = useState<Session | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+
+  const applySession = useCallback(async (next: Session | null) => {
+    setSession(next);
+    setUser(next?.user ?? null);
+    if (next?.access_token) {
+      await setAuthToken(next.access_token);
+      setActiveUserId(next.user.id);
+      setStatus("signedIn");
+    } else {
+      await clearAuthToken();
+      setActiveUserId(null);
+      setStatus("signedOut");
+    }
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+
+    if (!env.SUPABASE_URL || !env.SUPABASE_ANON_KEY) {
+      setSession(null);
+      setUser(null);
+      setStatus("signedOut");
+      return () => {
+        mounted = false;
+      };
+    }
+
+    supabase.auth
+      .getSession()
+      .then(({ data }) => {
+        if (mounted) {
+          void applySession(data.session);
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setStatus("signedOut");
+        }
+      });
+
+    const { data: subscription } = supabase.auth.onAuthStateChange(
+      (_event, nextSession) => {
+        if (mounted) {
+          void applySession(nextSession);
+        }
+      }
+    );
+
+    return () => {
+      mounted = false;
+      subscription.subscription.unsubscribe();
+    };
+  }, [applySession]);
+
+  const signInWithEmail = useCallback(async (email: string, password: string) => {
+    assertAuthConfigured();
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error) {
+      throw error;
+    }
+  }, []);
+
+  const signUpWithEmail = useCallback(async (email: string, password: string) => {
+    assertAuthConfigured();
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+    });
+    if (error) {
+      throw error;
+    }
+  }, []);
+
+  const requestPasswordReset = useCallback(async (email: string) => {
+    assertAuthConfigured();
+    const { error } = await supabase.auth.resetPasswordForEmail(email);
+    if (error) {
+      throw error;
+    }
+  }, []);
+
+  const signOut = useCallback(async () => {
+    await signOutAndClearUserData();
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      status,
+      session,
+      user,
+      signInWithEmail,
+      signUpWithEmail,
+      requestPasswordReset,
+      signOut,
+    }),
+    [status, session, user, signInWithEmail, signUpWithEmail, requestPasswordReset, signOut]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within AuthProvider.");
+  }
+  return context;
+}

--- a/apps/mobile/src/auth/AuthScreenShell.tsx
+++ b/apps/mobile/src/auth/AuthScreenShell.tsx
@@ -1,0 +1,46 @@
+import type { PropsWithChildren, ReactNode } from "react";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { ScreenHeader } from "../components/ScreenHeader";
+
+type AuthScreenShellProps = {
+  title: string;
+  subtitle?: string;
+  footer?: ReactNode;
+};
+
+export function AuthScreenShell({
+  title,
+  subtitle,
+  footer,
+  children,
+}: PropsWithChildren<AuthScreenShellProps>) {
+  return (
+    <View className="flex-1 bg-void">
+      <ScreenHeader title={title} subtitle="Force Collector" />
+      <ScrollView className="flex-1" contentContainerStyle={styles.content}>
+        {subtitle ? (
+          <Text className="text-sm font-space-medium text-secondary-text">
+            {subtitle}
+          </Text>
+        ) : null}
+        <View className="mt-6 gap-4">{children}</View>
+      </ScrollView>
+      {footer ? <View style={styles.footer}>{footer}</View> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingHorizontal: 20,
+    paddingTop: 24,
+    paddingBottom: 24,
+  },
+  footer: {
+    borderTopWidth: 1,
+    borderTopColor: "rgba(30,58,138,0.6)",
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    backgroundColor: "#0f172a",
+  },
+});

--- a/apps/mobile/src/auth/config.ts
+++ b/apps/mobile/src/auth/config.ts
@@ -1,0 +1,3 @@
+export const authConfig = {
+  bypassSplashWhenSignedIn: true,
+};

--- a/apps/mobile/src/auth/supabase.ts
+++ b/apps/mobile/src/auth/supabase.ts
@@ -1,0 +1,24 @@
+import { createClient } from "@supabase/supabase-js";
+import * as SecureStore from "expo-secure-store";
+import { env } from "../env";
+
+const secureStorage = {
+  async getItem(key: string) {
+    return SecureStore.getItemAsync(key);
+  },
+  async setItem(key: string, value: string) {
+    await SecureStore.setItemAsync(key, value);
+  },
+  async removeItem(key: string) {
+    await SecureStore.deleteItemAsync(key);
+  },
+};
+
+export const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY, {
+  auth: {
+    storage: secureStorage,
+    storageKey: "force_collector_supabase_auth",
+    persistSession: true,
+    autoRefreshToken: true,
+  },
+});

--- a/apps/mobile/src/offline/session.ts
+++ b/apps/mobile/src/offline/session.ts
@@ -1,8 +1,16 @@
 import { clearAuthToken } from "../api/auth";
+import { queryClient } from "../api/queryClient";
+import { supabase } from "../auth/supabase";
 import { clearUserDatabase, setActiveUserId } from "./db";
 
 export async function signOutAndClearUserData() {
+  try {
+    await supabase.auth.signOut();
+  } catch {
+    // Ignore network failures and continue clearing local data.
+  }
   await clearAuthToken();
   await clearUserDatabase();
   setActiveUserId(null);
+  queryClient.clear();
 }


### PR DESCRIPTION
Closes #8

Issue: https://github.com/jayvicsanantonio/force-collector/issues/8
Run: https://github.com/jayvicsanantonio/force-collector/actions/runs/21872309670

<details>
<summary>Codex summary</summary>

Auth + session routing is wired through Supabase with SecureStore, and the Splash/Auth flows now route deterministically per Issue #8. Added email/password auth screens, session-aware splash bypass, auth gate on tabs, and a sign-out flow that clears SecureStore tokens, local DB, and query cache before returning to Splash.

What changed
- Added Supabase client with SecureStore-backed auth storage and new `AuthProvider`/config for session state in `apps/mobile/src/auth/supabase.ts` and `apps/mobile/src/auth/AuthProvider.tsx`.
- Implemented auth screens (Sign in, Create account, Forgot password) and shared layout in `apps/mobile/app/(auth)/*` and `apps/mobile/src/auth/AuthScreenShell.tsx`.
- Updated Splash routing and session bypass logic in `apps/mobile/app/index.tsx`, plus auth-gated tabs in `apps/mobile/app/(tabs)/_layout.tsx`.
- Sign-out now clears Supabase session, SecureStore token, local SQLite cache, and query cache, and routes to Splash in `apps/mobile/src/offline/session.ts` and `apps/mobile/app/(tabs)/profile/settings.tsx`.
- Added `@supabase/supabase-js` dependency in `apps/mobile/package.json`.

How to test
1) `cd apps/mobile`
2) `npm install`
3) `npm run start`
4) Verify flows:
   - Splash → “Get Started” → Create Account
   - Splash → “Access Existing Data” → Sign In
   - Successful sign-in routes to Dashboard
   - Relaunch with valid session skips Splash (if `bypassSplashWhenSignedIn` is true)
   - Sign out clears data and returns to Splash
   - Offline relaunch after sign-in opens Dashboard (cached DB)

Limitations / follow-ups
- Only email/password auth is implemented (magic link / Apple / Google remain optional).
- Password reset uses Supabase’s default email flow; no in-app reset screen post-link.
- Supabase env vars must be provided (`SUPABASE_URL`, `SUPABASE_ANON_KEY`) or auth actions will error.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user authentication with account creation and sign-in screens.
  * Introduced password recovery functionality for forgotten passwords.
  * Implemented automatic session verification on app launch with loading indicator.
  * Added auth-based navigation to route users to appropriate screens based on sign-in status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->