### PR TITLE
Codex: #9 [MVP] Push notifications end-to-end (register token, preferences, deep links)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -9,7 +9,7 @@ const config: ExpoConfig = {
   orientation: "portrait",
   newArchEnabled: true,
   userInterfaceStyle: "dark",
-  plugins: ["expo-router"],
+  plugins: ["expo-router", "expo-notifications"],
   extra: {
     API_BASE_URL: process.env.API_BASE_URL ?? "",
     SUPABASE_URL: process.env.SUPABASE_URL ?? "",

--- a/apps/mobile/app/(tabs)/collection/details.tsx
+++ b/apps/mobile/app/(tabs)/collection/details.tsx
@@ -2,8 +2,17 @@ import { useEffect } from "react";
 import { Pressable, StyleSheet, Text } from "react-native";
 import PlaceholderScreen from "../../../src/PlaceholderScreen";
 import { track } from "../../../src/observability";
+import { useLocalSearchParams } from "expo-router";
 
 export default function FigureDetailsScreen() {
+  const params = useLocalSearchParams<{
+    figureId?: string;
+    userFigureId?: string;
+    source?: string;
+  }>();
+  const target =
+    params.userFigureId ?? params.figureId ?? undefined;
+
   useEffect(() => {
     track("figure_details_viewed");
   }, []);
@@ -11,7 +20,11 @@ export default function FigureDetailsScreen() {
   return (
     <PlaceholderScreen
       title="Figure Details & Lore"
-      description="Placeholder for figure details, lore, and actions."
+      description={
+        target
+          ? `Opened from ${params.source ?? "notification"} for ${target}.`
+          : "Placeholder for figure details, lore, and actions."
+      }
     >
       <Pressable
         style={styles.button}

--- a/apps/mobile/app/(tabs)/home/index.tsx
+++ b/apps/mobile/app/(tabs)/home/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
-import { router } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
 import { Button } from "../../../src/components/Button";
 import { Card } from "../../../src/components/Card";
 import { Chip } from "../../../src/components/Chip";
@@ -18,6 +18,10 @@ export default function HomeScreen() {
   const { allegiance, toggleAllegiance, accentTextClass } = useTheme();
   const summary = useDashboardSummary();
   const { isOnline } = useOfflineStatus();
+  const params = useLocalSearchParams<{
+    highlight?: string;
+    figureId?: string;
+  }>();
 
   useEffect(() => {
     track("dashboard_viewed");
@@ -40,6 +44,16 @@ export default function HomeScreen() {
       />
       <ScrollView className="flex-1" contentContainerStyle={styles.content}>
         <View className="gap-6">
+          {(params.highlight || params.figureId) && (
+            <View className="rounded-2xl border border-hud-line/60 bg-raised-surface/70 px-4 py-3">
+              <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+                Notification
+              </Text>
+              <Text className="mt-2 text-sm text-frost-text">
+                Opened for {params.highlight ?? params.figureId}.
+              </Text>
+            </View>
+          )}
           <View>
             <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
               Buttons

--- a/apps/mobile/app/(tabs)/profile/settings.tsx
+++ b/apps/mobile/app/(tabs)/profile/settings.tsx
@@ -1,15 +1,141 @@
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import {
+  Alert,
+  Pressable,
+  StyleSheet,
+  Switch,
+  Text,
+  View,
+} from "react-native";
 import { router } from "expo-router";
 import PlaceholderScreen from "../../../src/PlaceholderScreen";
 import { signOutAndClearUserData } from "../../../src/offline/session";
 import { captureError, track } from "../../../src/observability";
+import { useMe, useUpdateMe } from "../../../src/api/me";
+import { useAuth } from "../../../src/auth/AuthProvider";
+import * as Notifications from "expo-notifications";
+import { hasPushPermission, registerPushTokenIfNeeded } from "../../../src/notifications/push";
+import { useEffect, useState } from "react";
+
+const defaultNotificationPrefs = {
+  price_drop: true,
+  restock: true,
+  new_drop: true,
+};
 
 export default function SettingsScreen() {
+  const { user } = useAuth();
+  const { data } = useMe();
+  const updateMe = useUpdateMe();
+
+  const [notificationPrefs, setNotificationPrefs] = useState(
+    defaultNotificationPrefs
+  );
+
+  useEffect(() => {
+    if (!data?.profile.preferences) {
+      return;
+    }
+    setNotificationPrefs({
+      ...defaultNotificationPrefs,
+      ...(data.profile.preferences.notifications ?? {}),
+    });
+  }, [data?.profile.preferences]);
+
+  async function requestPermissionWithExplanation() {
+    const alreadyGranted = await hasPushPermission();
+    if (alreadyGranted) {
+      return true;
+    }
+
+    return new Promise<boolean>((resolve) => {
+      Alert.alert(
+        "Enable notifications",
+        "Force Collector uses notifications for price drops, restocks, and new releases you care about.",
+        [
+          {
+            text: "Not now",
+            style: "cancel",
+            onPress: () => resolve(false),
+          },
+          {
+            text: "Allow",
+            onPress: async () => {
+              await Notifications.requestPermissionsAsync();
+              resolve(await hasPushPermission());
+            },
+          },
+        ]
+      );
+    });
+  }
+
+  async function updateNotificationPreference(key: string, value: boolean) {
+    const granted = value ? await requestPermissionWithExplanation() : true;
+    if (!granted) {
+      return;
+    }
+
+    const next = { ...notificationPrefs, [key]: value };
+    setNotificationPrefs(next);
+
+    updateMe.mutate({
+      preferences: {
+        ...(data?.profile.preferences ?? {}),
+        notifications: next,
+      },
+    });
+
+    if (value && user?.id) {
+      await registerPushTokenIfNeeded(user.id);
+    }
+
+    track("notifications_toggle_changed", { key, value });
+  }
+
   return (
     <PlaceholderScreen
       title="Settings"
-      description="Placeholder for notification, account, and privacy settings."
+      description="Manage notifications, account, and privacy settings."
     >
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>Notifications</Text>
+        <Text style={styles.cardText}>
+          Choose which alerts you want to receive.
+        </Text>
+        <View style={styles.toggleRow}>
+          <Text style={styles.toggleLabel}>Price drops</Text>
+          <Switch
+            value={notificationPrefs.price_drop}
+            onValueChange={(value) =>
+              void updateNotificationPreference("price_drop", value)
+            }
+            trackColor={{ false: "#1c2a3d", true: "#2d5aa7" }}
+            thumbColor="#e6f0ff"
+          />
+        </View>
+        <View style={styles.toggleRow}>
+          <Text style={styles.toggleLabel}>Restocks</Text>
+          <Switch
+            value={notificationPrefs.restock}
+            onValueChange={(value) =>
+              void updateNotificationPreference("restock", value)
+            }
+            trackColor={{ false: "#1c2a3d", true: "#2d5aa7" }}
+            thumbColor="#e6f0ff"
+          />
+        </View>
+        <View style={styles.toggleRow}>
+          <Text style={styles.toggleLabel}>New drops & pre-orders</Text>
+          <Switch
+            value={notificationPrefs.new_drop}
+            onValueChange={(value) =>
+              void updateNotificationPreference("new_drop", value)
+            }
+            trackColor={{ false: "#1c2a3d", true: "#2d5aa7" }}
+            thumbColor="#e6f0ff"
+          />
+        </View>
+      </View>
       <View style={styles.card}>
         <Text style={styles.cardTitle}>Account</Text>
         <Text style={styles.cardText}>
@@ -75,6 +201,23 @@ const styles = StyleSheet.create({
     marginTop: 8,
     color: "#e6f0ff",
     fontSize: 13,
+  },
+  toggleRow: {
+    marginTop: 12,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    borderRadius: 10,
+    backgroundColor: "#0f1826",
+    borderWidth: 1,
+    borderColor: "#22324d",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  toggleLabel: {
+    color: "#e6f0ff",
+    fontSize: 13,
+    fontWeight: "600",
   },
   button: {
     marginTop: 12,

--- a/apps/mobile/app/(tabs)/wishlist/details.tsx
+++ b/apps/mobile/app/(tabs)/wishlist/details.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+import { Pressable, StyleSheet, Text } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import PlaceholderScreen from "../../../src/PlaceholderScreen";
+import { track } from "../../../src/observability";
+
+export default function WishlistDetailsScreen() {
+  const params = useLocalSearchParams<{
+    figureId?: string;
+    userFigureId?: string;
+  }>();
+
+  const target = params.userFigureId ?? params.figureId ?? undefined;
+
+  useEffect(() => {
+    track("wishlist_details_viewed");
+  }, []);
+
+  return (
+    <PlaceholderScreen
+      title="Wishlist Item"
+      description={
+        target
+          ? `Opened from notification for ${target}.`
+          : "Placeholder for wishlist item details and price alerts."
+      }
+    >
+      <Pressable
+        style={styles.button}
+        onPress={() => track("wishlist_price_alert_configured")}
+      >
+        <Text style={styles.buttonText}>Manage Price Alert</Text>
+      </Pressable>
+    </PlaceholderScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    backgroundColor: "#1c2a3d",
+    borderWidth: 1,
+    borderColor: "#2f4566",
+  },
+  buttonText: {
+    color: "#e6f0ff",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/app/(tabs)/wishlist/index.tsx
+++ b/apps/mobile/app/(tabs)/wishlist/index.tsx
@@ -1,4 +1,4 @@
-import { router } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
 import { useEffect } from "react";
 import {
   FlatList,
@@ -18,6 +18,7 @@ export default function WishlistScreen() {
   const { isOnline, syncNow } = useOfflineStatus();
   const { data } = useFiguresByStatus("WISHLIST");
   const updateStatus = useUpdateFigureStatus();
+  const params = useLocalSearchParams<{ figureId?: string }>();
 
   useEffect(() => {
     track("wishlist_viewed");
@@ -75,6 +76,15 @@ export default function WishlistScreen() {
         data={data}
         keyExtractor={(item) => item.id}
         contentContainerStyle={styles.list}
+        ListHeaderComponent={
+          params.figureId ? (
+            <View style={styles.banner}>
+              <Text style={styles.bannerText}>
+                Highlighted from notification: {params.figureId}
+              </Text>
+            </View>
+          ) : null
+        }
         ListEmptyComponent={
           <Text style={styles.emptyText}>No cached wishlist items yet.</Text>
         }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -8,6 +8,9 @@ import { OfflineProvider } from "../src/offline/OfflineProvider";
 import { AuthProvider } from "../src/auth/AuthProvider";
 import { useEffect } from "react";
 import { initObservability, wrapWithObservability } from "../src/observability";
+import { configureNotificationHandler } from "../src/notifications/push";
+import { registerNotificationRouting } from "../src/notifications/routing";
+import { PushRegistrationGate } from "../src/notifications/PushRegistrationGate";
 import {
   useFonts,
   SpaceGrotesk_400Regular,
@@ -26,6 +29,9 @@ function RootLayout() {
 
   useEffect(() => {
     initObservability();
+    configureNotificationHandler();
+    const teardown = registerNotificationRouting();
+    return teardown;
   }, []);
 
   if (!fontsLoaded) {
@@ -35,6 +41,7 @@ function RootLayout() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
+        <PushRegistrationGate />
         <OfflineProvider>
           <ThemeProvider>
             <Stack>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -21,6 +21,7 @@
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",
     "expo-linking": "~8.0.11",
+    "expo-notifications": "~0.29.0",
     "expo-router": "~6.0.22",
     "expo-secure-store": "~14.0.3",
     "expo-sqlite": "~14.0.6",

--- a/apps/mobile/src/api/me.ts
+++ b/apps/mobile/src/api/me.ts
@@ -1,8 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
-import { MeResponseSchema } from "@force-collector/shared";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { ApiSuccessSchema, MeResponseSchema, UpdateMeRequestSchema } from "@force-collector/shared";
 import { env } from "../env";
 import { apiRequest } from "./client";
 import { queryKeys } from "./queryKeys";
+import { queryClient } from "./queryClient";
 
 export function useMe() {
   return useQuery({
@@ -14,5 +15,26 @@ export function useMe() {
         auth: "required",
       }),
     enabled: Boolean(env.API_BASE_URL),
+  });
+}
+
+export function useUpdateMe() {
+  return useMutation({
+    mutationFn: (payload: unknown) => {
+      const parsed = UpdateMeRequestSchema.safeParse(payload);
+      if (!parsed.success) {
+        throw new Error("Invalid profile update payload.");
+      }
+      return apiRequest({
+        path: "/v1/me",
+        method: "PATCH",
+        body: parsed.data,
+        schema: ApiSuccessSchema,
+        auth: "required",
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.me() });
+    },
   });
 }

--- a/apps/mobile/src/api/push.ts
+++ b/apps/mobile/src/api/push.ts
@@ -1,0 +1,20 @@
+import { ApiSuccessSchema, PushRegisterRequestSchema } from "@force-collector/shared";
+import { apiRequest } from "./client";
+
+export async function registerPushToken(payload: {
+  expo_push_token: string;
+  device_id?: string;
+}) {
+  const parsed = PushRegisterRequestSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new Error("Invalid push registration payload.");
+  }
+
+  return apiRequest({
+    path: "/v1/push/register",
+    method: "POST",
+    body: parsed.data,
+    schema: ApiSuccessSchema,
+    auth: "required",
+  });
+}

--- a/apps/mobile/src/notifications/PushRegistrationGate.tsx
+++ b/apps/mobile/src/notifications/PushRegistrationGate.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { useAuth } from "../auth/AuthProvider";
+import { registerPushTokenIfNeeded } from "./push";
+
+export function PushRegistrationGate() {
+  const { user } = useAuth();
+
+  useEffect(() => {
+    if (!user?.id) {
+      return;
+    }
+
+    void registerPushTokenIfNeeded(user.id);
+  }, [user?.id]);
+
+  return null;
+}

--- a/apps/mobile/src/notifications/push.ts
+++ b/apps/mobile/src/notifications/push.ts
@@ -1,0 +1,108 @@
+import * as Notifications from "expo-notifications";
+import Constants from "expo-constants";
+import * as SecureStore from "expo-secure-store";
+import { Platform } from "react-native";
+import { registerPushToken } from "../api/push";
+import { captureError, track } from "../observability";
+
+const DEVICE_ID_KEY = "push_device_id";
+const LAST_TOKEN_KEY = "push_last_token";
+const LAST_USER_KEY = "push_last_user";
+
+function isPermissionGranted(permission: Notifications.NotificationPermissionsStatus) {
+  return (
+    permission.granted ||
+    permission.ios?.status ===
+      Notifications.IosAuthorizationStatus.AUTHORIZED ||
+    permission.ios?.status ===
+      Notifications.IosAuthorizationStatus.PROVISIONAL
+  );
+}
+
+async function ensureAndroidChannel() {
+  if (Platform.OS !== "android") {
+    return;
+  }
+  await Notifications.setNotificationChannelAsync("default", {
+    name: "Default",
+    importance: Notifications.AndroidImportance.DEFAULT,
+  });
+}
+
+async function getOrCreateDeviceId() {
+  const existing = await SecureStore.getItemAsync(DEVICE_ID_KEY);
+  if (existing) {
+    return existing;
+  }
+  const generated = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  await SecureStore.setItemAsync(DEVICE_ID_KEY, generated);
+  return generated;
+}
+
+async function getExpoPushToken() {
+  const projectId =
+    Constants.easConfig?.projectId ??
+    (Constants.expoConfig?.extra as { eas?: { projectId?: string } } | undefined)
+      ?.eas?.projectId;
+
+  const tokenResponse = projectId
+    ? await Notifications.getExpoPushTokenAsync({ projectId })
+    : await Notifications.getExpoPushTokenAsync();
+
+  return tokenResponse.data;
+}
+
+export async function registerPushTokenIfNeeded(userId: string) {
+  try {
+    const permission = await Notifications.getPermissionsAsync();
+    if (!isPermissionGranted(permission)) {
+      return { status: "permission_denied" as const };
+    }
+
+    await ensureAndroidChannel();
+
+    const expoPushToken = await getExpoPushToken();
+    const deviceId = await getOrCreateDeviceId();
+
+    const [lastToken, lastUser] = await Promise.all([
+      SecureStore.getItemAsync(LAST_TOKEN_KEY),
+      SecureStore.getItemAsync(LAST_USER_KEY),
+    ]);
+
+    if (lastToken === expoPushToken && lastUser === userId) {
+      return { status: "noop" as const, expoPushToken };
+    }
+
+    await registerPushToken({
+      expo_push_token: expoPushToken,
+      device_id: deviceId,
+    });
+
+    await Promise.all([
+      SecureStore.setItemAsync(LAST_TOKEN_KEY, expoPushToken),
+      SecureStore.setItemAsync(LAST_USER_KEY, userId),
+    ]);
+
+    track("push_token_registered");
+
+    return { status: "registered" as const, expoPushToken };
+  } catch (error) {
+    captureError(error, { source: "push", action: "register" });
+    return { status: "error" as const };
+  }
+}
+
+export function configureNotificationHandler() {
+  Notifications.setNotificationHandler({
+    handleNotification: async () => ({
+      shouldShowAlert: true,
+      shouldPlaySound: true,
+      shouldSetBadge: false,
+    }),
+  });
+}
+
+export async function hasPushPermission() {
+  const permission = await Notifications.getPermissionsAsync();
+  return isPermissionGranted(permission);
+}

--- a/apps/mobile/src/notifications/routing.ts
+++ b/apps/mobile/src/notifications/routing.ts
@@ -1,0 +1,89 @@
+import type { NotificationResponse } from "expo-notifications";
+import * as Notifications from "expo-notifications";
+import { router } from "expo-router";
+
+export type NotificationPayload = {
+  type?: string;
+  figure_id?: string;
+  user_figure_id?: string;
+  deeplink?: string;
+  path?: string;
+};
+
+function buildPath(base: string, params?: Record<string, string | undefined>) {
+  if (!params) {
+    return base;
+  }
+  const entries = Object.entries(params).filter(([, value]) => Boolean(value));
+  if (!entries.length) {
+    return base;
+  }
+  const query = new URLSearchParams(
+    entries.map(([key, value]) => [key, value as string])
+  ).toString();
+  return `${base}?${query}`;
+}
+
+export function resolveNotificationPath(payload: NotificationPayload) {
+  if (!payload) {
+    return null;
+  }
+
+  if (payload.deeplink) {
+    return payload.deeplink;
+  }
+
+  if (payload.path) {
+    return payload.path;
+  }
+
+  const type = payload.type?.toLowerCase();
+  switch (type) {
+    case "price_drop":
+      return buildPath("/wishlist/details", {
+        userFigureId: payload.user_figure_id,
+        figureId: payload.figure_id,
+      });
+    case "restock":
+      return buildPath("/wishlist", {
+        figureId: payload.figure_id,
+      });
+    case "new_drop":
+    case "preorder":
+      if (payload.figure_id || payload.user_figure_id) {
+        return buildPath("/collection/details", {
+          figureId: payload.figure_id,
+          userFigureId: payload.user_figure_id,
+        });
+      }
+      return "/home";
+    default:
+      return null;
+  }
+}
+
+function handleResponse(response: NotificationResponse) {
+  const payload = response.notification.request.content.data as
+    | NotificationPayload
+    | undefined;
+  const path = resolveNotificationPath(payload ?? {});
+  if (path) {
+    router.push(path);
+  }
+}
+
+export function registerNotificationRouting() {
+  const subscription = Notifications.addNotificationResponseReceivedListener(
+    handleResponse
+  );
+
+  Notifications.getLastNotificationResponseAsync().then((response) => {
+    if (response) {
+      handleResponse(response);
+    }
+  });
+
+  return () => {
+    subscription.remove();
+  };
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -25,3 +25,5 @@ enabled = true
 [functions]
 [functions.health]
 verify_jwt = false
+[functions.api]
+verify_jwt = true

--- a/supabase/functions/_shared/push.ts
+++ b/supabase/functions/_shared/push.ts
@@ -1,0 +1,59 @@
+export type PushNotificationType =
+  | "price_drop"
+  | "restock"
+  | "new_drop"
+  | "preorder";
+
+export type PushPayload = {
+  type: PushNotificationType;
+  figure_id?: string;
+  user_figure_id?: string;
+  deeplink: string;
+};
+
+export type ExpoPushMessage = {
+  to: string;
+  title: string;
+  body: string;
+  data: PushPayload;
+  sound?: "default";
+};
+
+export function buildDeepLinkPath(payload: PushPayload) {
+  return payload.deeplink;
+}
+
+export function shouldSendForPreferences(
+  preferences: Record<string, boolean> | null | undefined,
+  type: PushNotificationType
+) {
+  if (!preferences) {
+    return true;
+  }
+  const key = type === "new_drop" ? "new_drop" : type;
+  const value = preferences[key];
+  return value !== false;
+}
+
+export async function sendExpoPushMessages(messages: ExpoPushMessage[]) {
+  if (!messages.length) {
+    return { success: true, data: [] };
+  }
+
+  const response = await fetch("https://exp.host/--/api/v2/push/send", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(messages),
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(
+      `Expo push request failed: ${response.status} ${response.statusText}`
+    );
+  }
+
+  return data;
+}

--- a/supabase/functions/api/index.ts
+++ b/supabase/functions/api/index.ts
@@ -1,0 +1,96 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...corsHeaders },
+  });
+}
+
+function normalizePath(pathname: string) {
+  const segments = pathname.split("/").filter(Boolean);
+  const v1Index = segments.indexOf("v1");
+  if (v1Index >= 0) {
+    return `/${segments.slice(v1Index).join("/")}`;
+  }
+  if (segments.length >= 2) {
+    return `/${segments.slice(-2).join("/")}`;
+  }
+  return pathname;
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  const url = new URL(req.url);
+  const path = normalizePath(url.pathname);
+
+  if (path === "/v1/push/register" && req.method === "POST") {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return jsonResponse({ message: "Supabase env not configured." }, 500);
+    }
+
+    const authHeader = req.headers.get("authorization") ?? "";
+    const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+      global: {
+        headers: { Authorization: authHeader },
+      },
+    });
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return jsonResponse({ message: "Unauthorized." }, 401);
+    }
+
+    let payload: { expo_push_token?: string; device_id?: string } | null = null;
+    try {
+      payload = await req.json();
+    } catch {
+      return jsonResponse({ message: "Invalid JSON body." }, 400);
+    }
+
+    const expoPushToken = payload?.expo_push_token?.trim();
+    if (!expoPushToken) {
+      return jsonResponse({ message: "expo_push_token is required." }, 400);
+    }
+
+    const now = new Date().toISOString();
+    const record = {
+      user_id: user.id,
+      expo_push_token: expoPushToken,
+      device_id: payload?.device_id ?? null,
+      updated_at: now,
+      last_seen_at: now,
+    };
+
+    const onConflict = record.device_id
+      ? "user_id,device_id"
+      : "expo_push_token";
+
+    const { error: upsertError } = await supabase
+      .from("push_tokens")
+      .upsert(record, { onConflict });
+
+    if (upsertError) {
+      return jsonResponse({ message: upsertError.message }, 500);
+    }
+
+    return jsonResponse({ success: true });
+  }
+
+  return jsonResponse({ message: "Not found." }, 404);
+});

--- a/supabase/migrations/20260211000000_push_tokens.sql
+++ b/supabase/migrations/20260211000000_push_tokens.sql
@@ -1,0 +1,41 @@
+-- Push notification device tokens (REQUIREMENTS.md §9.2)
+
+create table if not exists public.push_tokens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  expo_push_token text not null,
+  device_id text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now()
+);
+
+create unique index if not exists push_tokens_token_idx
+  on public.push_tokens(expo_push_token);
+
+create unique index if not exists push_tokens_user_device_idx
+  on public.push_tokens(user_id, device_id)
+  where device_id is not null;
+
+alter table public.push_tokens enable row level security;
+
+create policy "Push tokens are viewable by owner"
+  on public.push_tokens
+  for select
+  using (auth.uid() = user_id);
+
+create policy "Push tokens are insertable by owner"
+  on public.push_tokens
+  for insert
+  with check (auth.uid() = user_id);
+
+create policy "Push tokens are updatable by owner"
+  on public.push_tokens
+  for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Push tokens are deletable by owner"
+  on public.push_tokens
+  for delete
+  using (auth.uid() = user_id);


### PR DESCRIPTION
Closes #9

Issue: https://github.com/jayvicsanantonio/force-collector/issues/9
Run: https://github.com/jayvicsanantonio/force-collector/actions/runs/21912295092

<details>
<summary>Codex summary</summary>

**What changed**
- Added push token storage and policies in `supabase/migrations/20260211000000_push_tokens.sql`.
- Added a Supabase Edge Function router at `supabase/functions/api/index.ts` for `POST /v1/push/register` and a shared Expo push helper in `supabase/functions/_shared/push.ts`. Enabled JWT verification in `supabase/config.toml`.
- Added mobile push registration, permission handling, and notification routing (`apps/mobile/src/notifications/*`), plus a `PushRegistrationGate` wired into `apps/mobile/app/_layout.tsx`.
- Implemented notification preferences UI and persistence in `apps/mobile/app/(tabs)/profile/settings.tsx`.
- Added deep-linkable placeholder screens for wishlist and figure details and surfaced notification context in home/wishlist screens.
- Added `expo-notifications` dependency and plugin.

**How to test (commands)**
1. `cd apps/mobile && npm install`
2. `cd apps/mobile && npm run start`
3. (Optional backend) `supabase start` then deploy the `api` function and apply migrations.

Manual checks:
- Log in, open Settings → Notifications, toggle any option on, allow permissions, and verify a `POST /v1/push/register` call is made.
- Send a test push with payload `{ type, figure_id/user_figure_id, deeplink }` and verify it opens `/wishlist/details`, `/wishlist`, `/collection/details`, or `/home` as expected.

**Limitations / follow-ups**
- The notification preferences are persisted via `PATCH /v1/me`; ensure your backend returns `ApiSuccess` and stores `preferences.notifications`.
- Deep-link destinations are currently placeholder screens; they display the IDs but don’t yet select real items.
- If you want automatic permission prompting outside Settings, we can add a first-run prompt gated by user preferences.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Enabled push notifications across the app with user permission management
* Added notification preferences in settings to control alerts for price drops, restocks, and new releases
* Implemented deep linking to navigate directly to relevant product details when tapping notifications
* Added visual indicators throughout the app to highlight content accessed via notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->