### PR TITLE
Codex: #12 [MVP] Implement Scan Results screen + one-tap add actions (Collection/Wishlist)

### DIFF
--- a/apps/mobile/app/(tabs)/search/index.tsx
+++ b/apps/mobile/app/(tabs)/search/index.tsx
@@ -12,7 +12,7 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { router } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { MaterialIcons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
@@ -39,6 +39,7 @@ type ScanState =
 const BARCODE_LENGTHS = new Set([8, 12, 13, 14]);
 
 export default function ScannerScreen() {
+  const params = useLocalSearchParams<{ restart?: string }>();
   const { accentTextClass, accentBorderClass } = useTheme();
   const [permission, requestPermission] = useCameraPermissions();
   const scanLookup = useScanLookup();
@@ -74,6 +75,19 @@ export default function ScannerScreen() {
       setScanState(permission.canAskAgain ? "requesting" : "permission-denied");
     }
   }, [permission]);
+
+  useEffect(() => {
+    if (!params.restart) {
+      return;
+    }
+    processingRef.current = false;
+    setLookupError(null);
+    if (permission?.granted) {
+      setScanState("scanning");
+    } else {
+      setScanState(permission?.canAskAgain ? "requesting" : "permission-denied");
+    }
+  }, [params.restart, permission?.canAskAgain, permission?.granted]);
 
   useEffect(() => {
     let active = true;

--- a/apps/mobile/app/(tabs)/search/results.tsx
+++ b/apps/mobile/app/(tabs)/search/results.tsx
@@ -1,15 +1,74 @@
-import { useEffect, useMemo } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
-import { useLocalSearchParams } from "expo-router";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Alert,
+  Image,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import { router, useLocalSearchParams } from "expo-router";
 import {
   ScanLookupResponseSchema,
+  type Figure,
   type ScanLookupResponse,
 } from "@force-collector/shared";
-import PlaceholderScreen from "../../../src/PlaceholderScreen";
+import { Button } from "../../../src/components/Button";
+import { Badge } from "../../../src/components/Badge";
+import { Card } from "../../../src/components/Card";
+import { ScreenHeader } from "../../../src/components/ScreenHeader";
+import { StatCard } from "../../../src/components/StatCard";
+import { useAuth } from "../../../src/auth/AuthProvider";
+import { createUserFigure, updateUserFigureStatus } from "../../../src/api/user-figures";
+import { useOfflineStatus } from "../../../src/offline/OfflineProvider";
+import {
+  applyServerUpdate,
+  getFigureByFigureId,
+} from "../../../src/offline/cache";
+import {
+  useFigureByFigureId,
+  useUpdateFigureStatus,
+  useUpsertFigureRecord,
+} from "../../../src/offline/hooks";
+import type { FigureStatus } from "../../../src/offline/types";
 import { track } from "../../../src/observability";
+
+const CONFIDENCE_CONFIRM_THRESHOLD = 0.65;
+
+function formatPercent(value: number) {
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatPrice(price: number | null, currency: string | null) {
+  if (price === null || !currency) {
+    return "—";
+  }
+  return `${currency} ${price.toFixed(2)}`;
+}
+
+function confirmAction(title: string, message: string, confirmLabel: string) {
+  return new Promise<boolean>((resolve) => {
+    Alert.alert(title, message, [
+      { text: "Cancel", style: "cancel", onPress: () => resolve(false) },
+      { text: confirmLabel, style: "default", onPress: () => resolve(true) },
+    ]);
+  });
+}
 
 export default function ScanResultsScreen() {
   const params = useLocalSearchParams<{ payload?: string }>();
+  const { user } = useAuth();
+  const { isOnline } = useOfflineStatus();
+  const updateStatus = useUpdateFigureStatus();
+  const upsertFigure = useUpsertFigureRecord();
+  const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<{
+    figureId: string;
+    status: FigureStatus;
+  } | null>(null);
+
   const payload = useMemo<ScanLookupResponse | null>(() => {
     if (!params.payload) {
       return null;
@@ -23,70 +82,401 @@ export default function ScanResultsScreen() {
     }
   }, [params.payload]);
 
+  const match = payload?.match ?? null;
+  const related = payload?.related ?? [];
+  const listings = payload?.listings ?? [];
+  const confidence = payload?.confidence ?? 0;
+  const lowConfidence =
+    match !== null && confidence > 0 && confidence < CONFIDENCE_CONFIRM_THRESHOLD;
+  const primaryRecord = useFigureByFigureId(match?.id ?? null);
+
   useEffect(() => {
     track("scan_results_viewed");
   }, []);
 
-  return (
-    <PlaceholderScreen
-      title="Scan Results"
-      description={
-        payload?.match
-          ? "Review the detected figure and take action."
-          : "No scan payload found. Try scanning again."
+  useEffect(() => {
+    return () => {
+      if (noticeTimer.current) {
+        clearTimeout(noticeTimer.current);
       }
-    >
-      {payload?.match ? (
-        <View className="rounded-2xl border border-hud-line/60 bg-raised-surface/70 px-4 py-4">
-          <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
-            Primary Match
+    };
+  }, []);
+
+  const setFeedback = useCallback((message: string) => {
+    setNotice(message);
+    if (noticeTimer.current) {
+      clearTimeout(noticeTimer.current);
+    }
+    noticeTimer.current = setTimeout(() => {
+      setNotice(null);
+    }, 3000);
+  }, []);
+
+  const listingSummary = useMemo(() => {
+    const total = listings.length;
+    const inStock = listings.filter((listing) => listing.in_stock === true).length;
+    const prices = listings
+      .map((listing) => listing.current_price)
+      .filter((price): price is number => typeof price === "number");
+    const lowest = prices.length ? Math.min(...prices) : null;
+    const currency = listings.find((listing) => listing.current_price !== null)?.currency ?? null;
+    return { total, inStock, lowest, currency };
+  }, [listings]);
+
+  const handleScanAgain = useCallback(() => {
+    router.replace({
+      pathname: "/search",
+      params: { restart: "1" },
+    });
+  }, []);
+
+  const updateExistingStatus = useCallback(
+    async (id: string, status: FigureStatus) => {
+      if (isOnline) {
+        try {
+          const response = await updateUserFigureStatus(id, status);
+          const updatedAt = response.updated_at ?? new Date().toISOString();
+          await applyServerUpdate(id, status, updatedAt);
+          return { synced: true };
+        } catch {
+          // Fall back to offline queue.
+        }
+      }
+
+      const updated = await updateStatus(id, status);
+      return { synced: false, updated };
+    },
+    [isOnline, updateStatus]
+  );
+
+  const createNewStatus = useCallback(
+    async (figure: Figure, status: FigureStatus) => {
+      const updatedAt = new Date().toISOString();
+      if (isOnline) {
+        try {
+          const response = await createUserFigure({
+            figure_id: figure.id,
+            status,
+            condition: "UNKNOWN",
+            user_id: user?.id,
+          });
+          await upsertFigure({
+            id: response.id,
+            figureId: figure.id,
+            name: figure.name,
+            series: figure.series ?? null,
+            status,
+            updatedAt: response.updated_at ?? updatedAt,
+            syncPending: false,
+          });
+          return { synced: true };
+        } catch {
+          // Fall back to offline queue.
+        }
+      }
+
+      const tempId = `pending-${figure.id}-${Date.now()}`;
+      await upsertFigure(
+        {
+          id: tempId,
+          figureId: figure.id,
+          name: figure.name,
+          series: figure.series ?? null,
+          status,
+          updatedAt,
+          syncPending: true,
+        },
+        {
+          figureId: figure.id,
+          status,
+          name: figure.name,
+          series: figure.series ?? null,
+          updatedAt,
+        }
+      );
+      return { synced: false };
+    },
+    [isOnline, upsertFigure, user?.id]
+  );
+
+  const handleAdd = useCallback(
+    async (figure: Figure, status: FigureStatus, source: "primary" | "related") => {
+      if (pendingAction) {
+        return;
+      }
+
+      if (lowConfidence && source === "primary") {
+        const confirm = await confirmAction(
+          "Low confidence match",
+          `We matched this scan with ${formatPercent(confidence)} confidence. Add anyway?`,
+          "Add"
+        );
+        if (!confirm) {
+          return;
+        }
+      }
+
+      setPendingAction({ figureId: figure.id, status });
+      try {
+        const existing =
+          source === "primary"
+            ? primaryRecord.data
+            : await getFigureByFigureId(figure.id);
+
+        if (existing?.status === status) {
+          Alert.alert(
+            status === "OWNED" ? "Already in collection" : "Already on wishlist",
+            `This figure is already marked as ${status === "OWNED" ? "owned" : "wishlist"}.`
+          );
+          return;
+        }
+
+        if (source === "primary") {
+          if (status === "OWNED") {
+            track("scan_results_add_collection");
+          } else {
+            track("scan_results_add_wishlist");
+          }
+        } else {
+          track("scan_results_related_add", { status });
+        }
+
+        const result = existing
+          ? await updateExistingStatus(existing.id, status)
+          : await createNewStatus(figure, status);
+
+        setFeedback(
+          result.synced
+            ? status === "OWNED"
+              ? "Added to collection."
+              : "Added to wishlist."
+            : "Saved offline. Syncing when online."
+        );
+      } catch {
+        setFeedback("Unable to add right now. Try again.");
+      } finally {
+        setPendingAction(null);
+      }
+    },
+    [
+      confidence,
+      createNewStatus,
+      lowConfidence,
+      pendingAction,
+      primaryRecord.data,
+      setFeedback,
+      updateExistingStatus,
+    ]
+  );
+
+  if (!payload || !match) {
+    return (
+      <View className="flex-1 bg-void">
+        <ScreenHeader title="Scan Results" subtitle="No match detected" />
+        <View className="flex-1 items-center justify-center px-6">
+          <Text className="text-center text-sm text-secondary-text">
+            We couldn't find a valid scan payload. Try scanning again.
           </Text>
-          <Text className="mt-2 text-lg font-space-semibold text-frost-text">
-            {payload.match.name}
-          </Text>
-          <Text className="mt-1 text-xs text-secondary-text">
-            {payload.match.series} · Wave {payload.match.wave} ·{" "}
-            {payload.match.release_year}
-          </Text>
-          <Text className="mt-2 text-xs text-secondary-text">
-            Confidence: {(payload.confidence * 100).toFixed(0)}%
-          </Text>
+          <View className="mt-6 w-full max-w-sm">
+            <Button label="Scan Again" onPress={handleScanAgain} />
+          </View>
         </View>
-      ) : null}
-      <Pressable
-        style={styles.button}
-        onPress={() => track("scan_results_add_collection")}
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1 bg-void">
+      <ScreenHeader
+        title="Scan Results"
+        subtitle="Confirm the detected match"
+        rightSlot={
+          <Pressable
+            onPress={handleScanAgain}
+            className="flex-row items-center gap-2 rounded-full border border-hud-line/70 bg-overlay-ink/70 px-3 py-1"
+          >
+            <MaterialIcons name="qr-code-scanner" size={14} color="#94a3b8" />
+            <Text className="text-[10px] font-space-semibold uppercase tracking-widest text-secondary-text">
+              Scan
+            </Text>
+          </Pressable>
+        }
+      />
+
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 40 }}
       >
-        <Text style={styles.buttonText}>Add to Collection</Text>
-      </Pressable>
-      <Pressable
-        style={styles.button}
-        onPress={() => track("scan_results_add_wishlist")}
-      >
-        <Text style={styles.buttonText}>Add to Wishlist</Text>
-      </Pressable>
-      <Pressable
-        style={styles.button}
-        onPress={() => track("scan_results_related_add")}
-      >
-        <Text style={styles.buttonText}>Add Related Figure</Text>
-      </Pressable>
-    </PlaceholderScreen>
+        <View className="gap-6 pt-6">
+          {notice ? (
+            <View className="rounded-2xl border border-hud-line/60 bg-raised-surface/70 px-4 py-3">
+              <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+                Status
+              </Text>
+              <Text className="mt-2 text-sm text-frost-text">{notice}</Text>
+            </View>
+          ) : null}
+
+          {!isOnline ? (
+            <Card>
+              <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+                Offline Mode
+              </Text>
+              <Text className="mt-2 text-sm text-frost-text">
+                Actions will be saved and synced once you're back online.
+              </Text>
+            </Card>
+          ) : null}
+
+          <Card className="gap-4">
+            <View className="flex-row items-start gap-4">
+              {match.primary_image_url ? (
+                <Image
+                  source={{ uri: match.primary_image_url }}
+                  className="h-24 w-20 rounded-xl"
+                  resizeMode="cover"
+                />
+              ) : (
+                <View className="h-24 w-20 items-center justify-center rounded-xl border border-hud-line/70 bg-raised-surface/60">
+                  <MaterialIcons name="image" size={20} color="#94a3b8" />
+                </View>
+              )}
+
+              <View className="flex-1">
+                <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+                  Primary Match
+                </Text>
+                <Text className="mt-2 text-lg font-space-semibold text-frost-text">
+                  {match.name}
+                </Text>
+                <Text className="mt-1 text-xs text-secondary-text">
+                  {match.series} · Wave {match.wave} · {match.release_year}
+                </Text>
+                <Text className="mt-2 text-xs text-muted-text">
+                  Confidence: {formatPercent(confidence)}
+                </Text>
+              </View>
+            </View>
+
+            <View className="flex-row flex-wrap gap-2">
+              {primaryRecord.data?.status === "OWNED" ? (
+                <Badge label="Owned" tone="owned" />
+              ) : null}
+              {primaryRecord.data?.status === "WISHLIST" ? (
+                <Badge label="Wishlist" tone="wishlist" />
+              ) : null}
+              {match.exclusivity ? (
+                <Badge label={match.exclusivity} tone="exclusive" />
+              ) : null}
+              {lowConfidence ? (
+                <Badge label="Verify Match" tone="neutral" iconName="report" />
+              ) : null}
+            </View>
+
+            <View className="gap-3">
+              <Button
+                label="Add to Collection"
+                loading={
+                  pendingAction?.figureId === match.id &&
+                  pendingAction.status === "OWNED"
+                }
+                onPress={() => handleAdd(match, "OWNED", "primary")}
+              />
+              <Button
+                label="Add to Wishlist"
+                variant="secondary"
+                loading={
+                  pendingAction?.figureId === match.id &&
+                  pendingAction.status === "WISHLIST"
+                }
+                onPress={() => handleAdd(match, "WISHLIST", "primary")}
+              />
+            </View>
+          </Card>
+
+          {listings.length ? (
+            <View>
+              <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+                Listing Summary
+              </Text>
+              <View className="mt-3 flex-row gap-3">
+                <View className="flex-1">
+                  <StatCard
+                    label="Listings"
+                    value={listingSummary.total.toString()}
+                    helper={`${listingSummary.inStock} in stock`}
+                  />
+                </View>
+                <View className="flex-1">
+                  <StatCard
+                    label="Lowest"
+                    value={formatPrice(
+                      listingSummary.lowest,
+                      listingSummary.currency
+                    )}
+                    helper="Current price"
+                  />
+                </View>
+              </View>
+            </View>
+          ) : null}
+
+          {related.length ? (
+            <View>
+              <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+                Other Versions
+              </Text>
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={{ paddingVertical: 16, gap: 12 }}
+              >
+                {related.map((item) => (
+                  <Card key={item.id} className="w-56 gap-3">
+                    <View className="flex-row items-start gap-3">
+                      {item.primary_image_url ? (
+                        <Image
+                          source={{ uri: item.primary_image_url }}
+                          className="h-16 w-14 rounded-lg"
+                          resizeMode="cover"
+                        />
+                      ) : (
+                        <View className="h-16 w-14 items-center justify-center rounded-lg border border-hud-line/70 bg-raised-surface/60">
+                          <MaterialIcons name="image" size={16} color="#94a3b8" />
+                        </View>
+                      )}
+                      <View className="flex-1">
+                        <Text className="text-sm font-space-semibold text-frost-text">
+                          {item.name}
+                        </Text>
+                        <Text className="mt-1 text-[11px] text-secondary-text">
+                          {item.series} · Wave {item.wave}
+                        </Text>
+                      </View>
+                    </View>
+                    <View className="flex-row items-center justify-between">
+                      <Text className="text-[11px] text-muted-text">
+                        {item.release_year} · {item.exclusivity}
+                      </Text>
+                      <Pressable
+                        onPress={() => handleAdd(item, "OWNED", "related")}
+                        onLongPress={() => handleAdd(item, "WISHLIST", "related")}
+                        className="h-9 w-9 items-center justify-center rounded-full border border-hud-line/70 bg-hud-surface"
+                        accessibilityLabel="Add related figure"
+                      >
+                        <MaterialIcons name="add" size={18} color="#38bdf8" />
+                      </Pressable>
+                    </View>
+                  </Card>
+                ))}
+              </ScrollView>
+              <Text className="text-[11px] text-muted-text">
+                Tap + to add to collection. Long-press to wishlist.
+              </Text>
+            </View>
+          ) : null}
+        </View>
+      </ScrollView>
+    </View>
   );
 }
-
-const styles = StyleSheet.create({
-  button: {
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    borderRadius: 10,
-    backgroundColor: "#1c2a3d",
-    borderWidth: 1,
-    borderColor: "#2f4566",
-  },
-  buttonText: {
-    color: "#e6f0ff",
-    fontSize: 14,
-    fontWeight: "600",
-  },
-});

--- a/apps/mobile/src/api/user-figures.ts
+++ b/apps/mobile/src/api/user-figures.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import {
+  UserFigureConditionSchema,
+  UserFigureStatusSchema,
+  type UserFigureStatus,
+} from "@force-collector/shared";
+import { apiRequest } from "./client";
+
+const UserFigureCreatePayloadSchema = z.object({
+  figure_id: z.string().uuid(),
+  status: UserFigureStatusSchema,
+  condition: UserFigureConditionSchema.optional(),
+  user_id: z.string().uuid().optional(),
+});
+
+const UserFigureUpdatePayloadSchema = z.object({
+  status: UserFigureStatusSchema,
+});
+
+const UserFigureCreateResponseSchema = z.object({
+  id: z.string(),
+  figure_id: z.string().optional().nullable(),
+  status: UserFigureStatusSchema.optional(),
+  updated_at: z.string().datetime().optional(),
+});
+
+const UserFigureUpdateResponseSchema = z.object({
+  id: z.string(),
+  status: UserFigureStatusSchema.optional(),
+  updated_at: z.string().datetime().optional(),
+});
+
+export async function createUserFigure(payload: {
+  figure_id: string;
+  status: UserFigureStatus;
+  condition?: z.infer<typeof UserFigureConditionSchema>;
+  user_id?: string;
+}) {
+  const parsed = UserFigureCreatePayloadSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new Error("Invalid user figure payload.");
+  }
+  return apiRequest({
+    path: "/v1/user-figures",
+    method: "POST",
+    body: parsed.data,
+    schema: UserFigureCreateResponseSchema,
+    auth: "required",
+  });
+}
+
+export async function updateUserFigureStatus(id: string, status: UserFigureStatus) {
+  const parsed = UserFigureUpdatePayloadSchema.safeParse({ status });
+  if (!parsed.success) {
+    throw new Error("Invalid user figure update payload.");
+  }
+  return apiRequest({
+    path: `/v1/user-figures/${id}`,
+    method: "PATCH",
+    body: parsed.data,
+    schema: UserFigureUpdateResponseSchema,
+    auth: "required",
+  });
+}

--- a/apps/mobile/src/offline/db.ts
+++ b/apps/mobile/src/offline/db.ts
@@ -46,6 +46,7 @@ async function migrate(db: SQLite.SQLiteDatabase) {
 
     CREATE TABLE IF NOT EXISTS figures (
       id TEXT PRIMARY KEY NOT NULL,
+      figure_id TEXT,
       name TEXT NOT NULL,
       series TEXT,
       status TEXT NOT NULL,
@@ -63,6 +64,12 @@ async function migrate(db: SQLite.SQLiteDatabase) {
       created_at TEXT NOT NULL
     );
   `);
+
+  try {
+    await db.execAsync("ALTER TABLE figures ADD COLUMN figure_id TEXT;");
+  } catch {
+    // Column already exists.
+  }
 }
 
 async function seedIfEmpty(db: SQLite.SQLiteDatabase) {

--- a/apps/mobile/src/offline/types.ts
+++ b/apps/mobile/src/offline/types.ts
@@ -2,6 +2,7 @@ export type FigureStatus = "OWNED" | "WISHLIST";
 
 export type CachedFigure = {
   id: string;
+  figureId: string | null;
   name: string;
   series: string | null;
   status: FigureStatus;
@@ -11,16 +12,30 @@ export type CachedFigure = {
   syncPending: boolean;
 };
 
-export type PendingMutation = {
-  id: string;
-  type: "status_update";
-  entityId: string;
-  payload: {
-    status: FigureStatus;
-    updatedAt: string;
-  };
-  createdAt: string;
-};
+export type PendingMutation =
+  | {
+      id: string;
+      type: "status_update";
+      entityId: string;
+      payload: {
+        status: FigureStatus;
+        updatedAt: string;
+      };
+      createdAt: string;
+    }
+  | {
+      id: string;
+      type: "create_user_figure";
+      entityId: string;
+      payload: {
+        figureId: string;
+        status: FigureStatus;
+        name: string;
+        series: string | null;
+        updatedAt: string;
+      };
+      createdAt: string;
+    };
 
 export type DashboardSummary = {
   totalOwned: number;


### PR DESCRIPTION
Closes #12

Issue: https://github.com/jayvicsanantonio/force-collector/issues/12
Run: https://github.com/jayvicsanantonio/force-collector/actions/runs/22011562446

<details>
<summary>Codex summary</summary>

**Summary**
- Built the Scan Results screen with primary match details, confidence handling, listing summary, related versions carousel, and scan-again shortcut. (`apps/mobile/app/(tabs)/search/results.tsx`, `apps/mobile/app/(tabs)/search/index.tsx`)
- Added user-figure create/update flow with online API calls, offline pending-create queueing, and cache support for `figure_id` plus sync resolution. (`apps/mobile/src/api/user-figures.ts`, `apps/mobile/src/offline/cache.ts`, `apps/mobile/src/offline/hooks.ts`, `apps/mobile/src/offline/sync.ts`, `apps/mobile/src/offline/types.ts`, `apps/mobile/src/offline/db.ts`)

**How to test**
1. `cd apps/mobile`
2. `npm run start`
3. Scan a barcode, confirm the results screen, and try:
   - `Add to Collection` / `Add to Wishlist`
   - Related item `+` (long-press for wishlist)
   - `Scan` shortcut to restart scanning

No automated tests were run (none defined).

**Limitations / follow-ups**
1. Offline-created items use temp IDs; if their status is changed before sync, it won’t reconcile into the pending create yet.
2. Duplicate detection relies on `figure_id` being present in the cache; existing cached items without it won’t be flagged until refreshed.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Completely redesigned search results screen with enhanced product details, pricing information, and stock availability
  * Added ability to save figures to your collection even without internet connection—automatic sync when reconnected
  * Intelligent confirmation flows with duplicate detection and smart handling of uncertain matches
  * View related product versions and rescan for additional results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->