### PR TITLE
Codex: #13 [MVP] Backend: implement Figures catalog endpoints (search, details, lore refresh)

### DIFF
--- a/supabase/migrations/20260214000000_lore_metadata.sql
+++ b/supabase/migrations/20260214000000_lore_metadata.sql
@@ -1,0 +1,3 @@
+alter table public.figures
+  add column if not exists lore_updated_at timestamptz,
+  add column if not exists lore_source text;


### PR DESCRIPTION
Closes #13

Issue: https://github.com/jayvicsanantonio/force-collector/issues/13
Run: https://github.com/jayvicsanantonio/force-collector/actions/runs/22019712537

<details>
<summary>Codex summary</summary>

**What changed**
- Added catalog endpoints in `supabase/functions/api/index.ts`:
  - `GET /v1/figures` with `query` and basic `filters` (era/series/faction).
  - `GET /v1/figures/{id}` returning canonical figure fields.
  - `GET /v1/figures/{id}/lore` with optional `refresh=true` to fetch and cache lore.
- Implemented Wookieepedia lore fetch + caching logic (TTL via `LORE_CACHE_HOURS`, default 168h).
- Added lore metadata columns in `supabase/migrations/20260214000000_lore_metadata.sql` (`lore_updated_at`, `lore_source`).

**How to test**
1. Apply Supabase migrations and start the `api` function as you normally do.
2. Call endpoints with an authenticated user session:
   - `GET /v1/figures?query=Vader&filters={"era":"ORIGINAL"}`
   - `GET /v1/figures/{id}`
   - `GET /v1/figures/{id}/lore` (and `?refresh=true` to force a refresh)

No automated tests found to run.

**Limitations / follow-ups**
1. Filters for `series` and `faction` are exact match; if you need fuzzy or case-insensitive matching, we can expand the query.
2. Lore refresh uses Wookieepedia (starwars.fandom.com) and requires `SUPABASE_SERVICE_ROLE_KEY` to persist updates. If missing, refresh will return a 500.
3. No pagination is implemented for `GET /v1/figures` beyond `limit`.

If you want, I can add basic pagination and/or return a richer lore payload shape.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added search and filtering capabilities for figures by era, series, and faction.
  * Introduced lore refresh functionality to fetch updated figure information.
  * Enhanced figure endpoints with improved data retrieval and authentication support.
  * Added database tracking for lore update timestamps and sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->