### PR TITLE
Codex: #15 [MVP] Backend: UserFigure CRUD + status transitions + editable fields

### DIFF
--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -90,6 +90,7 @@ export const UserFigureSchema = z.object({
     .regex(/^\d{4}-\d{2}-\d{2}$/)
     .optional(),
   notes: z.string().optional(),
+  photo_refs: z.array(z.string()).optional(),
   created_at: z.string().datetime(),
   updated_at: z.string().datetime(),
 });

--- a/supabase/functions/api/index.ts
+++ b/supabase/functions/api/index.ts
@@ -34,6 +34,11 @@ const FIGURE_SELECT_FIELDS =
   "id,name,subtitle,edition,series,wave,release_year,era,faction,exclusivity,upc,primary_image_url,lore,specs,created_at,updated_at";
 const FIGURE_LORE_FIELDS =
   "id,name,subtitle,edition,lore,lore_updated_at,lore_source";
+const USER_FIGURE_SELECT_FIELDS =
+  "id,user_id,figure_id,custom_figure_payload,status,condition,purchase_price,purchase_currency,purchase_date,notes,photo_refs,created_at,updated_at";
+const USER_FIGURE_STATUSES = ["OWNED", "WISHLIST", "PREORDER", "SOLD"] as const;
+const USER_FIGURE_CONDITIONS = ["MINT", "OPENED", "LOOSE", "UNKNOWN"] as const;
+const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 type ScanLookupResult = {
   match: Record<string, unknown> | null;
@@ -521,6 +526,68 @@ async function requireUser(supabase: AuthedSupabase) {
   return { user, error: null };
 }
 
+function isUserFigureStatus(value: unknown): value is (typeof USER_FIGURE_STATUSES)[number] {
+  return typeof value === "string" && USER_FIGURE_STATUSES.includes(value as any);
+}
+
+function isUserFigureCondition(
+  value: unknown
+): value is (typeof USER_FIGURE_CONDITIONS)[number] {
+  return typeof value === "string" && USER_FIGURE_CONDITIONS.includes(value as any);
+}
+
+function parseNumeric(value: unknown) {
+  if (value === null || value === undefined) {
+    return { ok: true, value: null as number | null };
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return { ok: true, value };
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return { ok: true, value: parsed };
+    }
+  }
+  return { ok: false, value: null as number | null };
+}
+
+function normalizeUserFigure(row: Record<string, unknown> | null) {
+  if (!row) {
+    return row;
+  }
+  const normalized = { ...row } as Record<string, unknown>;
+  if (typeof normalized.purchase_price === "string") {
+    const parsed = Number(normalized.purchase_price);
+    if (Number.isFinite(parsed)) {
+      normalized.purchase_price = parsed;
+    }
+  }
+  if (normalized.purchase_price === null) {
+    delete normalized.purchase_price;
+  }
+  if (normalized.purchase_currency === null) {
+    delete normalized.purchase_currency;
+  }
+  if (normalized.purchase_date === null) {
+    delete normalized.purchase_date;
+  }
+  if (normalized.notes === null) {
+    delete normalized.notes;
+  }
+  if (normalized.custom_figure_payload === null) {
+    delete normalized.custom_figure_payload;
+  }
+  if (Array.isArray(normalized.photo_refs)) {
+    normalized.photo_refs = normalized.photo_refs.filter(
+      (value) => typeof value === "string"
+    );
+  } else if (normalized.photo_refs === null) {
+    delete normalized.photo_refs;
+  }
+  return normalized;
+}
+
 serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
@@ -690,6 +757,422 @@ serve(async (req) => {
       lore_source: loreSource ?? null,
       refreshed,
     });
+  }
+
+  if (path === "/v1/user-figures" && req.method === "GET") {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return jsonResponse({ message: "Supabase env not configured." }, 500);
+    }
+
+    const authHeader = req.headers.get("authorization") ?? "";
+    const supabase = createAuthedClient(supabaseUrl, supabaseAnonKey, authHeader);
+    const { user, error: authError } = await requireUser(supabase);
+    if (authError || !user) {
+      return jsonResponse({ message: "Unauthorized." }, 401);
+    }
+
+    const statusParam = url.searchParams.get("status")?.toUpperCase();
+    if (statusParam && !isUserFigureStatus(statusParam)) {
+      return jsonResponse({ message: "Invalid status filter." }, 400);
+    }
+
+    const limitParam = Number(url.searchParams.get("limit") || 50);
+    const limit = Number.isFinite(limitParam)
+      ? Math.min(Math.max(limitParam, 1), 100)
+      : 50;
+
+    const query = url.searchParams.get("query")?.trim();
+    let figureIds: string[] | null = null;
+    if (query) {
+      const escaped = query.replace(/%/g, "\\%");
+      const { data: figures, error: figuresError } = await supabase
+        .from("figures")
+        .select("id")
+        .or(`name.ilike.%${escaped}%,subtitle.ilike.%${escaped}%`)
+        .limit(200);
+      if (figuresError) {
+        return jsonResponse({ message: figuresError.message }, 500);
+      }
+      figureIds = (figures ?? []).map((item) => item.id as string);
+      if (!figureIds.length) {
+        return jsonResponse({ items: [], next_cursor: null });
+      }
+    }
+
+    let builder = supabase
+      .from("user_figures")
+      .select(USER_FIGURE_SELECT_FIELDS)
+      .eq("user_id", user.id)
+      .order("updated_at", { ascending: false })
+      .limit(limit);
+
+    if (statusParam) {
+      builder = builder.eq("status", statusParam);
+    }
+    if (figureIds) {
+      builder = builder.in("figure_id", figureIds);
+    }
+
+    const { data, error } = await builder;
+    if (error) {
+      return jsonResponse({ message: error.message }, 500);
+    }
+
+    const items = (data ?? []).map((row) =>
+      normalizeUserFigure(row as Record<string, unknown>)
+    );
+    return jsonResponse({ items, next_cursor: null });
+  }
+
+  if (path === "/v1/user-figures" && req.method === "POST") {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return jsonResponse({ message: "Supabase env not configured." }, 500);
+    }
+
+    const authHeader = req.headers.get("authorization") ?? "";
+    const supabase = createAuthedClient(supabaseUrl, supabaseAnonKey, authHeader);
+    const { user, error: authError } = await requireUser(supabase);
+    if (authError || !user) {
+      return jsonResponse({ message: "Unauthorized." }, 401);
+    }
+
+    let payload: Record<string, unknown> | null = null;
+    try {
+      payload = await req.json();
+    } catch {
+      return jsonResponse({ message: "Invalid JSON body." }, 400);
+    }
+    if (!payload || Array.isArray(payload)) {
+      return jsonResponse({ message: "Invalid JSON body." }, 400);
+    }
+
+    if (payload?.user_id && payload.user_id !== user.id) {
+      return jsonResponse({ message: "Cannot create for another user." }, 403);
+    }
+
+    const figureId =
+      typeof payload?.figure_id === "string" ? payload.figure_id : null;
+    const customPayload =
+      payload?.custom_figure_payload && typeof payload.custom_figure_payload === "object"
+        ? payload.custom_figure_payload
+        : null;
+
+    if (!figureId && !customPayload) {
+      return jsonResponse(
+        { message: "figure_id or custom_figure_payload is required." },
+        400
+      );
+    }
+
+    if (!isUserFigureStatus(payload?.status)) {
+      return jsonResponse({ message: "Invalid status." }, 400);
+    }
+
+    const condition = payload?.condition;
+    if (condition !== undefined && !isUserFigureCondition(condition)) {
+      return jsonResponse({ message: "Invalid condition." }, 400);
+    }
+
+    const price = parseNumeric(payload?.purchase_price);
+    if (!price.ok) {
+      return jsonResponse({ message: "Invalid purchase_price." }, 400);
+    }
+
+    if (
+      payload?.purchase_date !== undefined &&
+      payload?.purchase_date !== null &&
+      (typeof payload.purchase_date !== "string" ||
+        !DATE_ONLY_REGEX.test(payload.purchase_date))
+    ) {
+      return jsonResponse({ message: "Invalid purchase_date." }, 400);
+    }
+
+    if (
+      payload?.purchase_currency !== undefined &&
+      payload?.purchase_currency !== null &&
+      typeof payload.purchase_currency !== "string"
+    ) {
+      return jsonResponse({ message: "Invalid purchase_currency." }, 400);
+    }
+
+    if (payload?.notes !== undefined && payload?.notes !== null && typeof payload.notes !== "string") {
+      return jsonResponse({ message: "Invalid notes." }, 400);
+    }
+
+    if (
+      payload?.photo_refs !== undefined &&
+      payload?.photo_refs !== null &&
+      (!Array.isArray(payload.photo_refs) ||
+        payload.photo_refs.some((value) => typeof value !== "string"))
+    ) {
+      return jsonResponse({ message: "Invalid photo_refs." }, 400);
+    }
+
+    const record: Record<string, unknown> = {
+      user_id: user.id,
+      status: payload.status,
+      updated_at: new Date().toISOString(),
+    };
+
+    if (figureId) {
+      record.figure_id = figureId;
+    }
+    if (customPayload) {
+      record.custom_figure_payload = customPayload;
+    }
+    if (condition !== undefined) {
+      record.condition = condition;
+    }
+    if (price.value !== null) {
+      record.purchase_price = price.value;
+    }
+    if (payload?.purchase_currency !== undefined) {
+      record.purchase_currency = payload.purchase_currency;
+    }
+    if (payload?.purchase_date !== undefined) {
+      record.purchase_date = payload.purchase_date;
+    }
+    if (payload?.notes !== undefined) {
+      record.notes = payload.notes;
+    }
+    if (payload?.photo_refs !== undefined) {
+      record.photo_refs = payload.photo_refs;
+    }
+
+    if (figureId) {
+      const { data: existing, error: existingError } = await supabase
+        .from("user_figures")
+        .select(USER_FIGURE_SELECT_FIELDS)
+        .eq("user_id", user.id)
+        .eq("figure_id", figureId)
+        .order("created_at", { ascending: true })
+        .limit(1);
+      if (existingError) {
+        return jsonResponse({ message: existingError.message }, 500);
+      }
+      const current = existing?.[0] as Record<string, unknown> | undefined;
+      if (current) {
+        const updates: Record<string, unknown> = { updated_at: record.updated_at };
+        let changed = false;
+        if (record.status && record.status !== current.status) {
+          updates.status = record.status;
+          changed = true;
+        }
+        if (record.condition !== undefined) {
+          updates.condition = record.condition;
+          changed = true;
+        }
+        if (record.purchase_price !== undefined) {
+          updates.purchase_price = record.purchase_price;
+          changed = true;
+        }
+        if (record.purchase_currency !== undefined) {
+          updates.purchase_currency = record.purchase_currency;
+          changed = true;
+        }
+        if (record.purchase_date !== undefined) {
+          updates.purchase_date = record.purchase_date;
+          changed = true;
+        }
+        if (record.notes !== undefined) {
+          updates.notes = record.notes;
+          changed = true;
+        }
+        if (record.photo_refs !== undefined) {
+          updates.photo_refs = record.photo_refs;
+          changed = true;
+        }
+
+        if (changed) {
+          const { data: updated, error: updateError } = await supabase
+            .from("user_figures")
+            .update(updates)
+            .eq("id", current.id as string)
+            .select(USER_FIGURE_SELECT_FIELDS)
+            .maybeSingle();
+          if (updateError) {
+            return jsonResponse({ message: updateError.message }, 500);
+          }
+          return jsonResponse({
+            ...normalizeUserFigure(updated as Record<string, unknown>),
+            duplicate: true,
+            updated: true,
+          });
+        }
+
+        return jsonResponse({
+          ...normalizeUserFigure(current),
+          duplicate: true,
+          updated: false,
+        });
+      }
+    }
+
+    const { data, error } = await supabase
+      .from("user_figures")
+      .insert(record)
+      .select(USER_FIGURE_SELECT_FIELDS)
+      .maybeSingle();
+    if (error) {
+      return jsonResponse({ message: error.message }, 500);
+    }
+
+    return jsonResponse(normalizeUserFigure(data as Record<string, unknown>));
+  }
+
+  if (path.startsWith("/v1/user-figures/") && req.method === "PATCH") {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return jsonResponse({ message: "Supabase env not configured." }, 500);
+    }
+
+    const authHeader = req.headers.get("authorization") ?? "";
+    const supabase = createAuthedClient(supabaseUrl, supabaseAnonKey, authHeader);
+    const { user, error: authError } = await requireUser(supabase);
+    if (authError || !user) {
+      return jsonResponse({ message: "Unauthorized." }, 401);
+    }
+
+    const segments = path.split("/").filter(Boolean);
+    const userFigureId = segments[2];
+    if (!userFigureId) {
+      return jsonResponse({ message: "User figure id is required." }, 400);
+    }
+
+    let payload: Record<string, unknown> | null = null;
+    try {
+      payload = await req.json();
+    } catch {
+      return jsonResponse({ message: "Invalid JSON body." }, 400);
+    }
+    if (!payload || Array.isArray(payload)) {
+      return jsonResponse({ message: "Invalid JSON body." }, 400);
+    }
+
+    const updates: Record<string, unknown> = {};
+
+    if ("status" in payload) {
+      if (!isUserFigureStatus(payload.status)) {
+        return jsonResponse({ message: "Invalid status." }, 400);
+      }
+      updates.status = payload.status;
+    }
+
+    if ("condition" in payload) {
+      if (payload.condition !== null && !isUserFigureCondition(payload.condition)) {
+        return jsonResponse({ message: "Invalid condition." }, 400);
+      }
+      updates.condition = payload.condition;
+    }
+
+    if ("purchase_price" in payload) {
+      const parsed = parseNumeric(payload.purchase_price);
+      if (!parsed.ok) {
+        return jsonResponse({ message: "Invalid purchase_price." }, 400);
+      }
+      updates.purchase_price = parsed.value;
+    }
+
+    if ("purchase_currency" in payload) {
+      if (
+        payload.purchase_currency !== null &&
+        payload.purchase_currency !== undefined &&
+        typeof payload.purchase_currency !== "string"
+      ) {
+        return jsonResponse({ message: "Invalid purchase_currency." }, 400);
+      }
+      updates.purchase_currency = payload.purchase_currency ?? null;
+    }
+
+    if ("purchase_date" in payload) {
+      if (
+        payload.purchase_date !== null &&
+        payload.purchase_date !== undefined &&
+        (typeof payload.purchase_date !== "string" ||
+          !DATE_ONLY_REGEX.test(payload.purchase_date))
+      ) {
+        return jsonResponse({ message: "Invalid purchase_date." }, 400);
+      }
+      updates.purchase_date = payload.purchase_date ?? null;
+    }
+
+    if ("notes" in payload) {
+      if (payload.notes !== null && payload.notes !== undefined && typeof payload.notes !== "string") {
+        return jsonResponse({ message: "Invalid notes." }, 400);
+      }
+      updates.notes = payload.notes ?? null;
+    }
+
+    if ("photo_refs" in payload) {
+      if (
+        payload.photo_refs !== null &&
+        payload.photo_refs !== undefined &&
+        (!Array.isArray(payload.photo_refs) ||
+          payload.photo_refs.some((value) => typeof value !== "string"))
+      ) {
+        return jsonResponse({ message: "Invalid photo_refs." }, 400);
+      }
+      updates.photo_refs = payload.photo_refs ?? null;
+    }
+
+    if (!Object.keys(updates).length) {
+      return jsonResponse({ message: "No valid fields to update." }, 400);
+    }
+
+    updates.updated_at = new Date().toISOString();
+
+    const { data, error } = await supabase
+      .from("user_figures")
+      .update(updates)
+      .eq("id", userFigureId)
+      .eq("user_id", user.id)
+      .select(USER_FIGURE_SELECT_FIELDS)
+      .maybeSingle();
+    if (error) {
+      return jsonResponse({ message: error.message }, 500);
+    }
+    if (!data) {
+      return jsonResponse({ message: "User figure not found." }, 404);
+    }
+
+    return jsonResponse(normalizeUserFigure(data as Record<string, unknown>));
+  }
+
+  if (path.startsWith("/v1/user-figures/") && req.method === "DELETE") {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return jsonResponse({ message: "Supabase env not configured." }, 500);
+    }
+
+    const authHeader = req.headers.get("authorization") ?? "";
+    const supabase = createAuthedClient(supabaseUrl, supabaseAnonKey, authHeader);
+    const { user, error: authError } = await requireUser(supabase);
+    if (authError || !user) {
+      return jsonResponse({ message: "Unauthorized." }, 401);
+    }
+
+    const segments = path.split("/").filter(Boolean);
+    const userFigureId = segments[2];
+    if (!userFigureId) {
+      return jsonResponse({ message: "User figure id is required." }, 400);
+    }
+
+    const { error } = await supabase
+      .from("user_figures")
+      .delete()
+      .eq("id", userFigureId)
+      .eq("user_id", user.id);
+    if (error) {
+      return jsonResponse({ message: error.message }, 500);
+    }
+
+    return jsonResponse({ success: true });
   }
 
   if (path === "/v1/push/register" && req.method === "POST") {

--- a/supabase/migrations/20260216000000_user_figure_photos.sql
+++ b/supabase/migrations/20260216000000_user_figure_photos.sql
@@ -1,0 +1,20 @@
+alter table public.user_figures
+add column if not exists figure_id uuid references public.figures(id) on delete set null;
+
+alter table public.user_figures
+add column if not exists custom_figure_payload jsonb;
+
+alter table public.user_figures
+add column if not exists condition public.user_figure_condition not null default 'UNKNOWN';
+
+alter table public.user_figures
+add column if not exists purchase_price numeric;
+
+alter table public.user_figures
+add column if not exists purchase_currency text;
+
+alter table public.user_figures
+add column if not exists purchase_date date;
+
+alter table public.user_figures
+add column if not exists photo_refs text[];


### PR DESCRIPTION
Closes #15

Issue: https://github.com/jayvicsanantonio/force-collector/issues/15
Run: https://github.com/jayvicsanantonio/force-collector/actions/runs/22068784932

<details>
<summary>Codex summary</summary>

**What Changed**
1. Added `GET/POST/PATCH/DELETE /v1/user-figures` in `supabase/functions/api/index.ts` with status filtering, duplicate detection (updates existing row, returns `duplicate` + `updated` flags), and editable fields (purchase details, condition, notes, photo refs) while enforcing user isolation.
2. Normalized API responses to avoid nulls on optional fields and to coerce numeric `purchase_price` to a number in `supabase/functions/api/index.ts`.
3. Added a migration to align `user_figures` with required fields (figure link, condition, purchase fields, photo refs) in `supabase/migrations/20260216000000_user_figure_photos.sql`.
4. Extended shared schema to include `photo_refs` in `packages/shared/src/entities.ts`.

**How To Test (Commands)**
1. Not run (no backend test runner found).
2. Manual smoke with curl (requires a valid bearer token):
```bash
curl -sS -X POST "$API_BASE_URL/v1/user-figures" \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"figure_id":"<uuid>","status":"OWNED","condition":"MINT","purchase_price":29.99,"purchase_currency":"USD","purchase_date":"2026-02-16","notes":"Test","photo_refs":["<path>"]}'
```
```bash
curl -sS -X PATCH "$API_BASE_URL/v1/user-figures/<id>" \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"status":"WISHLIST","notes":null,"purchase_price":null}'
```
```bash
curl -sS -X GET "$API_BASE_URL/v1/user-figures?status=OWNED&query=Vader" \
  -H "Authorization: Bearer $TOKEN"
```
```bash
curl -sS -X DELETE "$API_BASE_URL/v1/user-figures/<id>" \
  -H "Authorization: Bearer $TOKEN"
```

**Limitations / Follow-Ups**
1. `GET /v1/user-figures?query=...` only searches catalog figure `name`/`subtitle`; it does not search `notes` or `custom_figure_payload` yet.
2. The migration adds fields without removing legacy columns (e.g., `catalog_item_id`) to avoid destructive changes.

If you want, I can expand query search to include notes/custom figures or add a lightweight test harness for these endpoints.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive user figures management system enabling users to create, update, delete, and query their figure collections.
  * Introduced photo references support to attach images to figures.
  * Added tracking for figure condition, purchase price, purchase currency, and purchase date.
  * Implemented validation and normalization for all user-submitted data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->