### PR TITLE
Codex: #16 [MVP] Implement Figure Details & Lore screen (status, lore cache, share, edit entry)

### DIFF
--- a/apps/mobile/app/(tabs)/collection/details.tsx
+++ b/apps/mobile/app/(tabs)/collection/details.tsx
@@ -1,8 +1,119 @@
-import { useEffect } from "react";
-import { Pressable, StyleSheet, Text } from "react-native";
-import PlaceholderScreen from "../../../src/PlaceholderScreen";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Image,
+  Pressable,
+  ScrollView,
+  Share,
+  Text,
+  View,
+  useWindowDimensions,
+} from "react-native";
+import * as Linking from "expo-linking";
+import { MaterialIcons } from "@expo/vector-icons";
+import { router, useLocalSearchParams } from "expo-router";
+import { ScreenHeader } from "../../../src/components/ScreenHeader";
+import { Badge } from "../../../src/components/Badge";
+import { Button } from "../../../src/components/Button";
+import { Card } from "../../../src/components/Card";
+import { StatCard } from "../../../src/components/StatCard";
+import { useTheme } from "../../../src/theme/ThemeProvider";
+import { useOfflineStatus } from "../../../src/offline/OfflineProvider";
+import { applyServerUpdate } from "../../../src/offline/cache";
+import {
+  useFigureByFigureId,
+  useFigureById,
+  useUpdateFigureStatus,
+} from "../../../src/offline/hooks";
+import type { FigureStatus } from "../../../src/offline/types";
+import { updateUserFigureStatus } from "../../../src/api/user-figures";
+import { useFigure, useFigureLore } from "../../../src/api/figures";
 import { track } from "../../../src/observability";
-import { useLocalSearchParams } from "expo-router";
+
+type SpecEntry = {
+  label: string;
+  value: string;
+};
+
+const STATUS_OPTIONS: Array<{
+  value: FigureStatus;
+  label: string;
+  helper: string;
+}> = [
+  { value: "OWNED", label: "Owned", helper: "In collection" },
+  { value: "WISHLIST", label: "Wishlist", helper: "Hunting" },
+  { value: "PREORDER", label: "Preorder", helper: "Incoming" },
+  { value: "SOLD", label: "Sold", helper: "Archived" },
+];
+
+function formatSpecLabel(key: string) {
+  return key
+    .replace(/_/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .trim()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function formatSpecValue(value: unknown) {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? `${value}` : "—";
+  }
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => formatSpecValue(item)).join(", ");
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function extractAccessories(specs?: Record<string, unknown> | null) {
+  if (!specs) {
+    return [];
+  }
+  const raw =
+    (specs.accessories as unknown) ??
+    (specs.accessory as unknown) ??
+    (specs["accessory_list"] as unknown);
+  if (!raw) {
+    return [];
+  }
+  if (Array.isArray(raw)) {
+    return raw
+      .map((item) => {
+        if (typeof item === "string") {
+          return { name: item, detail: null };
+        }
+        if (item && typeof item === "object") {
+          const entry = item as Record<string, unknown>;
+          const name =
+            (entry.name as string | undefined) ??
+            (entry.title as string | undefined) ??
+            "Accessory";
+          const detail =
+            (entry.detail as string | undefined) ??
+            (entry.description as string | undefined) ??
+            null;
+          return { name, detail };
+        }
+        return null;
+      })
+      .filter((item): item is { name: string; detail: string | null } => !!item);
+  }
+  if (typeof raw === "string") {
+    return [{ name: raw, detail: null }];
+  }
+  return [];
+}
 
 export default function FigureDetailsScreen() {
   const params = useLocalSearchParams<{
@@ -10,56 +121,452 @@ export default function FigureDetailsScreen() {
     userFigureId?: string;
     source?: string;
   }>();
-  const target =
-    params.userFigureId ?? params.figureId ?? undefined;
+  const { accentTextClass, accentBorderClass } = useTheme();
+  const { isOnline } = useOfflineStatus();
+  const { width } = useWindowDimensions();
+  const updateStatusOffline = useUpdateFigureStatus();
+  const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [optimisticStatus, setOptimisticStatus] = useState<FigureStatus | null>(
+    null
+  );
+
+  const userFigureById = useFigureById(params.userFigureId ?? null);
+  const userFigureByFigureId = useFigureByFigureId(params.figureId ?? null);
+  const userFigure = userFigureById.data ?? userFigureByFigureId.data ?? null;
+  const figureId = userFigure?.figureId ?? params.figureId ?? null;
+  const figureQuery = useFigure(figureId);
+  const loreState = useFigureLore(figureId);
+
+  const figure = figureQuery.data ?? null;
+  const figureName = figure?.name ?? userFigure?.name ?? "Unknown figure";
+  const figureSeries = figure?.series ?? userFigure?.series ?? "Unknown series";
+  const statusValue = optimisticStatus ?? userFigure?.status ?? null;
+  const statusUpdating = optimisticStatus !== null;
 
   useEffect(() => {
-    track("figure_details_viewed");
+    track("figure_details_viewed", {
+      source: params.source ?? "unknown",
+    });
+  }, [params.source]);
+
+  useEffect(() => {
+    return () => {
+      if (noticeTimer.current) {
+        clearTimeout(noticeTimer.current);
+      }
+    };
   }, []);
 
-  return (
-    <PlaceholderScreen
-      title="Figure Details & Lore"
-      description={
-        target
-          ? `Opened from ${params.source ?? "notification"} for ${target}.`
-          : "Placeholder for figure details, lore, and actions."
+  const showNotice = useCallback((message: string) => {
+    setNotice(message);
+    if (noticeTimer.current) {
+      clearTimeout(noticeTimer.current);
+    }
+    noticeTimer.current = setTimeout(() => {
+      setNotice(null);
+    }, 3000);
+  }, []);
+
+  const handleStatusChange = useCallback(
+    async (nextStatus: FigureStatus) => {
+      if (!userFigure || userFigure.status === nextStatus) {
+        return;
       }
-    >
-      <Pressable
-        style={styles.button}
-        onPress={() => track("figure_status_changed")}
+
+      const previous = userFigure.status;
+      setOptimisticStatus(nextStatus);
+      track("figure_status_changed", { status: nextStatus });
+
+      if (!isOnline) {
+        await updateStatusOffline(userFigure.id, nextStatus);
+        setOptimisticStatus(null);
+        return;
+      }
+
+      try {
+        const response = await updateUserFigureStatus(userFigure.id, nextStatus);
+        const updatedAt = response.updated_at ?? new Date().toISOString();
+        await applyServerUpdate(userFigure.id, nextStatus, updatedAt);
+        setOptimisticStatus(null);
+      } catch {
+        setOptimisticStatus(null);
+        showNotice("Status update failed. Restored previous state.");
+        await applyServerUpdate(
+          userFigure.id,
+          previous,
+          userFigure.updatedAt ?? new Date().toISOString()
+        );
+      }
+    },
+    [isOnline, showNotice, updateStatusOffline, userFigure]
+  );
+
+  const handleShare = useCallback(async () => {
+    track("figure_shared");
+    const link = Linking.createURL("/collection/details", {
+      queryParams: {
+        figureId: figureId ?? undefined,
+        source: "share",
+      },
+    });
+    const message = `Check out ${figureName} on Force Collector.`;
+    try {
+      await Share.share({ message, url: link });
+    } catch {
+      showNotice("Share failed. Try again.");
+    }
+  }, [figureId, figureName, showNotice]);
+
+  const handleEdit = useCallback(() => {
+    track("figure_edit_opened");
+    router.push({
+      pathname: "/edit-figure",
+      params: {
+        userFigureId: userFigure?.id ?? undefined,
+        figureId: figureId ?? undefined,
+      },
+    });
+  }, [figureId, userFigure?.id]);
+
+  const handleDiscover = useCallback(() => {
+    track("figure_related_discovery_opened");
+    router.push("/search");
+  }, []);
+
+  const statusBadge = useMemo(() => {
+    switch (statusValue) {
+      case "OWNED":
+        return { label: "Owned", tone: "owned" as const };
+      case "WISHLIST":
+        return { label: "Wishlist", tone: "wishlist" as const };
+      case "PREORDER":
+        return { label: "Preorder", tone: "limited" as const };
+      case "SOLD":
+        return { label: "Sold", tone: "neutral" as const };
+      default:
+        return { label: "Not tracked", tone: "neutral" as const };
+    }
+  }, [statusValue]);
+
+  const specs = useMemo<SpecEntry[]>(() => {
+    const base: SpecEntry[] = [];
+    if (figure?.edition) {
+      base.push({ label: "Edition", value: figure.edition });
+    }
+    if (figure?.wave !== undefined) {
+      base.push({ label: "Wave", value: `${figure.wave}` });
+    }
+    if (figure?.release_year) {
+      base.push({ label: "Release Year", value: `${figure.release_year}` });
+    }
+    if (figure?.era) {
+      base.push({ label: "Era", value: figure.era });
+    }
+    if (figure?.faction) {
+      base.push({ label: "Faction", value: figure.faction });
+    }
+    if (figure?.exclusivity) {
+      base.push({ label: "Exclusivity", value: figure.exclusivity });
+    }
+    if (figure?.upc) {
+      base.push({ label: "UPC", value: figure.upc });
+    }
+
+    const extraSpecs = Object.entries(figure?.specs ?? {})
+      .filter(([key]) => key !== "accessories" && key !== "accessory_list")
+      .map(([key, value]) => ({
+        label: formatSpecLabel(key),
+        value: formatSpecValue(value),
+      }))
+      .filter((entry) => entry.value !== "—");
+
+    return [...base, ...extraSpecs];
+  }, [figure]);
+
+  const accessories = useMemo(
+    () => extractAccessories(figure?.specs ?? null),
+    [figure?.specs]
+  );
+
+  const lore = loreState.entry?.lore ?? figure?.lore ?? null;
+  const loreMeta = loreState.entry?.updatedAt ?? null;
+  const loreSource = loreState.entry?.source ?? null;
+  const loreUpdatedLabel = loreMeta
+    ? Number.isFinite(Date.parse(loreMeta))
+      ? new Date(loreMeta).toLocaleDateString()
+      : null
+    : null;
+
+  const isCompact = width < 360;
+
+  return (
+    <View className="flex-1 bg-void">
+      <ScreenHeader
+        title="Figure Details"
+        subtitle={figureSeries}
+      />
+      {notice ? (
+        <View
+          className="mx-4 mt-3 rounded-xl border border-danger-red/60 bg-danger-red/15 px-3 py-2"
+          accessibilityRole="alert"
+        >
+          <Text className="text-xs font-space-medium text-danger-red">
+            {notice}
+          </Text>
+        </View>
+      ) : null}
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 40 }}
       >
-        <Text style={styles.buttonText}>Change Status</Text>
-      </Pressable>
-      <Pressable
-        style={styles.button}
-        onPress={() => track("figure_edit_opened")}
-      >
-        <Text style={styles.buttonText}>Edit Figure Details</Text>
-      </Pressable>
-      <Pressable
-        style={styles.button}
-        onPress={() => track("figure_shared")}
-      >
-        <Text style={styles.buttonText}>Share Figure</Text>
-      </Pressable>
-    </PlaceholderScreen>
+        <View className={isCompact ? "gap-4" : "flex-row gap-4"}>
+          <View
+            className={`overflow-hidden rounded-2xl border border-hud-line/70 bg-hud-surface ${
+              isCompact ? "w-full" : "w-[42%]"
+            }`}
+          >
+            {figure?.primary_image_url ? (
+              <Image
+                source={{ uri: figure.primary_image_url }}
+                className={isCompact ? "h-52 w-full" : "h-44 w-full"}
+                resizeMode="cover"
+                accessibilityLabel={`${figureName} image`}
+              />
+            ) : (
+              <View className={isCompact ? "h-52 items-center justify-center" : "h-44 items-center justify-center"}>
+                <MaterialIcons name="image" size={32} color="#64748b" />
+                <Text className="mt-2 text-xs font-space-medium text-muted-text">
+                  No image
+                </Text>
+              </View>
+            )}
+          </View>
+          <View className="flex-1 justify-between">
+            <View className="gap-2">
+              <Text className="text-xl font-space-bold text-frost-text">
+                {figureName}
+              </Text>
+              {figure?.subtitle ? (
+                <Text className="text-sm font-space-medium text-secondary-text">
+                  {figure.subtitle}
+                </Text>
+              ) : null}
+              <View className="flex-row flex-wrap gap-2">
+                <Badge label={statusBadge.label} tone={statusBadge.tone} />
+                {figure?.exclusivity ? (
+                  <Badge label={figure.exclusivity} tone="exclusive" />
+                ) : null}
+                {figure?.era ? <Badge label={figure.era} tone="neutral" /> : null}
+              </View>
+            </View>
+            <View className="mt-3">
+              <Text className="text-[10px] font-space-semibold uppercase tracking-widest text-secondary-text">
+                Status
+              </Text>
+              <View className="mt-2 flex-row rounded-2xl border border-hud-line/60 bg-hud-surface p-1">
+                {STATUS_OPTIONS.map((option) => {
+                  const selected = statusValue === option.value;
+                  const disabled = !userFigure || statusUpdating;
+                  return (
+                    <Pressable
+                      key={option.value}
+                      onPress={() => handleStatusChange(option.value)}
+                      disabled={disabled}
+                      className={`flex-1 rounded-xl px-2 py-2 ${
+                        selected ? "bg-royal-blue/25" : ""
+                      } ${disabled ? "opacity-40" : ""}`}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected, disabled }}
+                      accessibilityLabel={`${option.label} status`}
+                    >
+                      <Text
+                        className={`text-center text-[11px] font-space-semibold ${
+                          selected ? "text-frost-text" : "text-secondary-text"
+                        }`}
+                      >
+                        {option.label}
+                      </Text>
+                      <Text className="mt-1 text-center text-[9px] text-muted-text">
+                        {option.helper}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+              {userFigure?.syncPending ? (
+                <Text className="mt-2 text-[10px] text-action-blue">
+                  Sync pending when you are online.
+                </Text>
+              ) : null}
+              {statusUpdating ? (
+                <Text className="mt-1 text-[10px] text-muted-text">
+                  Updating status...
+                </Text>
+              ) : null}
+            </View>
+          </View>
+        </View>
+
+        <View className="mt-6 gap-3">
+          <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+            Collection Summary
+          </Text>
+          <View className={isCompact ? "gap-3" : "flex-row gap-3"}>
+            <StatCard label="Status" value={statusBadge.label} />
+            <StatCard
+              label="Series"
+              value={figure?.series ?? figureSeries}
+            />
+          </View>
+        </View>
+
+        <View className="mt-6 gap-3">
+          <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+            Lore
+          </Text>
+          <Card className="gap-3">
+            {loreState.loading ? (
+              <Text className="text-sm text-muted-text">
+                Loading lore...
+              </Text>
+            ) : lore ? (
+              <Text className="text-sm leading-5 text-frost-text">
+                {lore}
+              </Text>
+            ) : (
+              <Text className="text-sm text-muted-text">
+                Lore unavailable for this figure.
+              </Text>
+            )}
+            <View className="flex-row items-center justify-between">
+              <Text className="text-[10px] text-muted-text">
+                {loreUpdatedLabel ? `Updated ${loreUpdatedLabel}` : "No update info"}
+              </Text>
+              <Text className={`text-[10px] ${accentTextClass}`}>
+                {loreSource ?? (loreState.stale ? "Stale cache" : "Cached")}
+              </Text>
+            </View>
+            {loreState.refreshing ? (
+              <Text className="text-[10px] text-muted-text">
+                Refreshing lore...
+              </Text>
+            ) : null}
+            {loreState.error ? (
+              <Text className="text-[10px] text-danger-red">
+                {loreState.error}
+              </Text>
+            ) : null}
+          </Card>
+        </View>
+
+        <View className="mt-6 gap-3">
+          <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+            Specs
+          </Text>
+          <View className="flex-row flex-wrap gap-3">
+            {specs.length === 0 ? (
+              <Card className="w-full">
+                <Text className="text-sm text-muted-text">
+                  Specs unavailable for this figure.
+                </Text>
+              </Card>
+            ) : (
+              specs.map((entry) => (
+                <View
+                  key={`${entry.label}-${entry.value}`}
+                  className={isCompact ? "w-full" : "w-[48%]"}
+                >
+                  <Card className="gap-2">
+                    <Text className="text-[10px] font-space-semibold uppercase tracking-widest text-secondary-text">
+                      {entry.label}
+                    </Text>
+                    <Text className="text-sm font-space-medium text-frost-text">
+                      {entry.value}
+                    </Text>
+                  </Card>
+                </View>
+              ))
+            )}
+          </View>
+        </View>
+
+        <View className="mt-6 gap-3">
+          <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+            Accessories
+          </Text>
+          {accessories.length === 0 ? (
+            <Card>
+              <Text className="text-sm text-muted-text">
+                No accessories listed.
+              </Text>
+            </Card>
+          ) : (
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={{ gap: 12 }}
+            >
+              {accessories.map((item, index) => (
+                <View key={`${item.name}-${index}`} className="w-48">
+                  <Card className="gap-2">
+                    <Text className="text-sm font-space-semibold text-frost-text">
+                      {item.name}
+                    </Text>
+                    {item.detail ? (
+                      <Text className="text-xs text-muted-text">
+                        {item.detail}
+                      </Text>
+                    ) : (
+                      <Text className="text-[10px] text-muted-text">
+                        Included accessory
+                      </Text>
+                    )}
+                  </Card>
+                </View>
+              ))}
+            </ScrollView>
+          )}
+        </View>
+
+        <View className="mt-6 gap-3">
+          <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+            Actions
+          </Text>
+          <View className="gap-3">
+            <Button
+              label="Edit Figure"
+              variant="secondary"
+              icon={<MaterialIcons name="edit" size={16} color="#f8fafc" />}
+              onPress={handleEdit}
+            />
+            <Button
+              label="Share Figure"
+              variant="ghost"
+              icon={<MaterialIcons name="share" size={16} color="#60a5fa" />}
+              onPress={handleShare}
+            />
+            <Pressable
+              onPress={handleDiscover}
+              className={`rounded-2xl border px-4 py-4 ${accentBorderClass} bg-hud-surface`}
+              accessibilityRole="button"
+              accessibilityLabel="Discover related figures"
+            >
+              <View className="flex-row items-center justify-between">
+                <View className="flex-1 pr-4">
+                  <Text className="text-sm font-space-semibold text-frost-text">
+                    Discover related figures
+                  </Text>
+                  <Text className="mt-1 text-xs text-muted-text">
+                    Jump back into the catalog to explore more from this era.
+                  </Text>
+                </View>
+                <MaterialIcons name="arrow-forward" size={18} color="#94a3b8" />
+              </View>
+            </Pressable>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
   );
 }
-
-const styles = StyleSheet.create({
-  button: {
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    borderRadius: 10,
-    backgroundColor: "#1c2a3d",
-    borderWidth: 1,
-    borderColor: "#2f4566",
-  },
-  buttonText: {
-    color: "#e6f0ff",
-    fontSize: 14,
-    fontWeight: "600",
-  },
-});

--- a/apps/mobile/src/api/figures.ts
+++ b/apps/mobile/src/api/figures.ts
@@ -1,0 +1,153 @@
+import { z } from "zod";
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { FigureSchema } from "@force-collector/shared";
+import { apiRequest } from "./client";
+import { env } from "../env";
+import { queryKeys } from "./queryKeys";
+import { useOfflineStatus } from "../offline/OfflineProvider";
+import {
+  getLoreCache,
+  isLoreStale,
+  setLoreCache,
+  type LoreCacheEntry,
+} from "../offline/loreCache";
+
+const FigureLoreResponseSchema = z.object({
+  figure_id: z.string(),
+  lore: z.string().nullable().optional(),
+  lore_updated_at: z.string().datetime().nullable().optional(),
+  lore_source: z.string().nullable().optional(),
+  refreshed: z.boolean().optional(),
+});
+
+type FigureLoreResponse = z.infer<typeof FigureLoreResponseSchema>;
+
+type LoreState = {
+  entry: LoreCacheEntry | null;
+  loading: boolean;
+  refreshing: boolean;
+  stale: boolean;
+  error: string | null;
+};
+
+export function useFigure(figureId?: string | null) {
+  return useQuery({
+    queryKey: queryKeys.figure(figureId ?? "unknown"),
+    enabled: Boolean(env.API_BASE_URL && figureId),
+    queryFn: () =>
+      apiRequest({
+        path: `/v1/figures/${figureId}`,
+        schema: FigureSchema,
+        auth: "required",
+      }),
+  });
+}
+
+async function fetchFigureLore(figureId: string, refresh: boolean) {
+  return apiRequest<FigureLoreResponse>({
+    path: `/v1/figures/${figureId}/lore${refresh ? "?refresh=1" : ""}`,
+    schema: FigureLoreResponseSchema,
+    auth: "required",
+  });
+}
+
+export function useFigureLore(figureId?: string | null) {
+  const { isOnline } = useOfflineStatus();
+  const canFetch = Boolean(env.API_BASE_URL);
+  const [state, setState] = useState<LoreState>({
+    entry: null,
+    loading: true,
+    refreshing: false,
+    stale: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      if (!figureId) {
+        setState({
+          entry: null,
+          loading: false,
+          refreshing: false,
+          stale: false,
+          error: null,
+        });
+        return;
+      }
+
+      setState((prev) => ({ ...prev, loading: true, error: null }));
+      const cached = await getLoreCache(figureId);
+      if (!active) {
+        return;
+      }
+
+      const stale = cached ? isLoreStale(cached.cachedAt) : true;
+      setState({
+        entry: cached,
+        loading: false,
+        refreshing: false,
+        stale,
+        error: null,
+      });
+
+      if (!isOnline || !stale || !canFetch) {
+        return;
+      }
+
+      setState((prev) => ({ ...prev, refreshing: true, error: null }));
+      try {
+        const response = await fetchFigureLore(figureId, stale);
+        if (!active) {
+          return;
+        }
+        const entry: LoreCacheEntry = {
+          figureId,
+          lore: response.lore ?? null,
+          updatedAt: response.lore_updated_at ?? null,
+          source: response.lore_source ?? null,
+          cachedAt: new Date().toISOString(),
+        };
+        await setLoreCache(entry);
+        if (!active) {
+          return;
+        }
+        setState({
+          entry,
+          loading: false,
+          refreshing: false,
+          stale: false,
+          error: null,
+        });
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+        setState((prev) => ({
+          ...prev,
+          refreshing: false,
+          error: "Lore refresh failed.",
+        }));
+      }
+    };
+
+    load().catch(() => {
+      if (active) {
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          refreshing: false,
+          error: "Lore cache failed.",
+        }));
+      }
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [canFetch, figureId, isOnline]);
+
+  return useMemo(() => state, [state]);
+}

--- a/apps/mobile/src/offline/hooks.ts
+++ b/apps/mobile/src/offline/hooks.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   getDashboardSummary,
+  getFigureById,
   getFigureByFigureId,
   listFiguresByStatus,
   upsertFigureRecord,
@@ -77,6 +78,41 @@ export function useFigureByFigureId(figureId?: string | null) {
     setData(figure);
     setLoading(false);
   }, [figureId]);
+
+  useEffect(() => {
+    let mounted = true;
+    load().catch(() => {
+      if (mounted) {
+        setLoading(false);
+      }
+    });
+    const unsubscribe = subscribeToFigureChanges(() => {
+      load().catch(() => undefined);
+    });
+    return () => {
+      mounted = false;
+      unsubscribe();
+    };
+  }, [load]);
+
+  return { data, loading, refresh: load };
+}
+
+export function useFigureById(id?: string | null) {
+  const [data, setData] = useState<CachedFigure | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!id) {
+      setData(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const figure = await getFigureById(id);
+    setData(figure);
+    setLoading(false);
+  }, [id]);
 
   useEffect(() => {
     let mounted = true;

--- a/apps/mobile/src/offline/loreCache.ts
+++ b/apps/mobile/src/offline/loreCache.ts
@@ -1,0 +1,69 @@
+import { getDatabase } from "./db";
+
+const LORE_CACHE_PREFIX = "lore:";
+const LORE_TTL_HOURS = 24;
+
+export type LoreCacheEntry = {
+  figureId: string;
+  lore: string | null;
+  updatedAt: string | null;
+  source: string | null;
+  cachedAt: string;
+};
+
+type RawLoreCacheEntry = {
+  figureId: string;
+  lore: string | null;
+  updatedAt: string | null;
+  source: string | null;
+  cachedAt: string;
+};
+
+function getCacheKey(figureId: string) {
+  return `${LORE_CACHE_PREFIX}${figureId}`;
+}
+
+export function isLoreStale(cachedAt: string) {
+  const cachedTime = Date.parse(cachedAt);
+  if (!Number.isFinite(cachedTime)) {
+    return true;
+  }
+  const ttlMs = LORE_TTL_HOURS * 60 * 60 * 1000;
+  return Date.now() - cachedTime > ttlMs;
+}
+
+export async function getLoreCache(
+  figureId: string
+): Promise<LoreCacheEntry | null> {
+  const db = await getDatabase();
+  const row = await db.getFirstAsync<{ value: string }>(
+    "SELECT value FROM metadata WHERE key = ?",
+    [getCacheKey(figureId)]
+  );
+  if (!row?.value) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(row.value) as RawLoreCacheEntry;
+    if (!parsed || parsed.figureId !== figureId || !parsed.cachedAt) {
+      return null;
+    }
+    return {
+      figureId,
+      lore: parsed.lore ?? null,
+      updatedAt: parsed.updatedAt ?? null,
+      source: parsed.source ?? null,
+      cachedAt: parsed.cachedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function setLoreCache(entry: LoreCacheEntry) {
+  const db = await getDatabase();
+  await db.runAsync(
+    "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+    [getCacheKey(entry.figureId), JSON.stringify(entry)]
+  );
+}

--- a/apps/mobile/src/offline/types.ts
+++ b/apps/mobile/src/offline/types.ts
@@ -1,4 +1,4 @@
-export type FigureStatus = "OWNED" | "WISHLIST";
+export type FigureStatus = "OWNED" | "WISHLIST" | "PREORDER" | "SOLD";
 
 export type CachedFigure = {
   id: string;


### PR DESCRIPTION
Closes #16

Issue: https://github.com/jayvicsanantonio/force-collector/issues/16
Run: https://github.com/jayvicsanantonio/force-collector/actions/runs/22105117960

<details>
<summary>Codex summary</summary>

Summary  
Implemented the Figure Details & Lore screen with a Stitch-aligned layout, status segmented control (optimistic update + rollback toast), lore/specs/accessories rendering, and action entry points for share/edit/related discovery.  
Added figure + lore fetching with local lore cache and stale refresh, and expanded offline status types to include `PREORDER` and `SOLD`.

Key changes  
- Replaced placeholder details screen with full UI and accessibility affordances: `apps/mobile/app/(tabs)/collection/details.tsx`  
- Added figure + lore API hooks with local lore cache refresh behavior: `apps/mobile/src/api/figures.ts`, `apps/mobile/src/offline/loreCache.ts`  
- Added offline hook for lookup by user-figure id: `apps/mobile/src/offline/hooks.ts`  
- Expanded offline status type: `apps/mobile/src/offline/types.ts`

How to test  
1. `cd apps/mobile`  
2. `npm run start`  
3. Navigate to Collection, open an item, and verify:  
   - Status switches immediately; on network failure it reverts with a toast.  
   - Lore/specs/accessories render; lore refreshes after TTL when online.  
   - Share opens OS share sheet with deep link.  
   - Edit opens the edit modal.  
   - “Discover related figures” opens Search.

Limitations / follow-ups  
1. Lore TTL is fixed at 24 hours; align with backend TTL if needed.  
2. User-specific fields beyond status (e.g., notes/condition) aren’t shown because there’s no user-figure GET-by-id API; add when available.  
3. Related discovery currently routes to the scanner tab; a dedicated related-figures flow could be wired later.

Tests not run (no test scripts in repo).
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned figure details screen with enhanced interactive elements including image, specifications, lore, and accessories display.
  * Added offline-supported status updates with immediate feedback and automatic recovery if updates fail.
  * Introduced sharing and editing actions for figures.
  * Expanded collection status options to include preorder and sold statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->