### PR TITLE
Codex: #19 [MVP] Backend: price checks + price history + alert dispatch scheduled jobs

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -27,3 +27,7 @@ enabled = true
 verify_jwt = false
 [functions.api]
 verify_jwt = true
+[functions.price-check]
+verify_jwt = false
+[functions.alert-dispatch]
+verify_jwt = false

--- a/supabase/functions/_shared/retailers/ebay.ts
+++ b/supabase/functions/_shared/retailers/ebay.ts
@@ -1,0 +1,97 @@
+export type EbayListingSnapshot = {
+  price: number | null;
+  currency: string | null;
+  inStock: boolean | null;
+  rawStatus?: string | null;
+};
+
+const DEFAULT_MARKETPLACE_ID = "EBAY-US";
+
+function parseNumber(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+export function extractEbayItemId(productUrl: string | null | undefined) {
+  if (!productUrl) {
+    return null;
+  }
+  const match = productUrl.match(/\/itm\/(\d+)/i);
+  if (match?.[1]) {
+    return match[1];
+  }
+  const alt = productUrl.match(/itm\/?(\d+)/i);
+  return alt?.[1] ?? null;
+}
+
+export async function fetchEbayListing(
+  itemId: string
+): Promise<EbayListingSnapshot | null> {
+  const token =
+    Deno.env.get("EBAY_OAUTH_TOKEN") ?? Deno.env.get("EBAY_BROWSE_TOKEN");
+  if (!token) {
+    throw new Error("Missing EBAY_OAUTH_TOKEN for eBay Browse API.");
+  }
+
+  const marketplaceId =
+    Deno.env.get("EBAY_MARKETPLACE_ID") ?? DEFAULT_MARKETPLACE_ID;
+
+  const response = await fetch(
+    `https://api.ebay.com/buy/browse/v1/item/${itemId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-EBAY-C-MARKETPLACE-ID": marketplaceId,
+      },
+    }
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `eBay Browse API failed: ${response.status} ${response.statusText} ${text}`
+    );
+  }
+
+  const data = (await response.json()) as Record<string, unknown>;
+  const priceObj = data.price as Record<string, unknown> | undefined;
+  const availability = data.availability as Record<string, unknown> | undefined;
+
+  const price = parseNumber(priceObj?.value);
+  const currency =
+    (typeof priceObj?.currency === "string"
+      ? priceObj?.currency
+      : undefined) ??
+    (typeof priceObj?.currencyCode === "string"
+      ? priceObj?.currencyCode
+      : null);
+
+  const status =
+    typeof availability?.availabilityStatus === "string"
+      ? availability.availabilityStatus
+      : null;
+
+  const inStock =
+    status === null
+      ? null
+      : status === "IN_STOCK"
+        ? true
+        : false;
+
+  return {
+    price,
+    currency,
+    inStock,
+    rawStatus: status,
+  };
+}

--- a/supabase/functions/alert-dispatch/index.ts
+++ b/supabase/functions/alert-dispatch/index.ts
@@ -1,0 +1,389 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+import {
+  sendExpoPushMessages,
+  shouldSendForPreferences,
+  type ExpoPushMessage,
+} from "../_shared/push.ts";
+
+const DEFAULT_COOLDOWN_HOURS = 24;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function getAdminClient() {
+  const url = Deno.env.get("SUPABASE_URL");
+  const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!url || !key) {
+    throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.");
+  }
+  return createClient(url, key, {
+    auth: { persistSession: false },
+  });
+}
+
+function unique<T>(values: T[]) {
+  return Array.from(new Set(values));
+}
+
+function toNumber(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+type Listing = {
+  id: string;
+  figure_id: string;
+  retailer: string;
+  current_price: number | string | null;
+  currency: string;
+  in_stock: boolean | null;
+};
+
+type HistoryPoint = {
+  price: number | string;
+  currency: string;
+  in_stock: boolean | null;
+  captured_at: string;
+};
+
+type AlertCandidate = {
+  listing: Listing;
+  current: HistoryPoint;
+  previous: HistoryPoint;
+};
+
+serve(async () => {
+  try {
+    const supabase = getAdminClient();
+    const now = new Date();
+
+    const { data: alerts, error: alertError } = await supabase
+      .from("price_alerts")
+      .select(
+        "id,user_id,user_figure_id,target_price,currency,enabled,retailers,notify_on_restock,cooldown_hours"
+      )
+      .eq("enabled", true);
+
+    if (alertError) {
+      throw alertError;
+    }
+
+    if (!alerts?.length) {
+      return jsonResponse({ ok: true, alerts: 0, sent: 0 });
+    }
+
+    const userFigureIds = unique(
+      alerts.map((alert) => alert.user_figure_id).filter(Boolean)
+    );
+
+    const { data: userFigures, error: userFigureError } = await supabase
+      .from("user_figures")
+      .select("id,figure_id")
+      .in("id", userFigureIds);
+
+    if (userFigureError) {
+      throw userFigureError;
+    }
+
+    const userFigureById = new Map(
+      (userFigures ?? []).map((row) => [row.id, row])
+    );
+
+    const figureIds = unique(
+      (userFigures ?? [])
+        .map((row) => row.figure_id)
+        .filter((value): value is string => Boolean(value))
+    );
+
+    const { data: figures, error: figureError } = await supabase
+      .from("figures")
+      .select("id,name")
+      .in("id", figureIds);
+
+    if (figureError) {
+      throw figureError;
+    }
+
+    const figureNameById = new Map(
+      (figures ?? []).map((row) => [row.id, row.name])
+    );
+
+    const { data: listings, error: listingError } = await supabase
+      .from("retailer_listings")
+      .select("id,figure_id,retailer,current_price,currency,in_stock")
+      .in("figure_id", figureIds);
+
+    if (listingError) {
+      throw listingError;
+    }
+
+    const listingsByFigure = new Map<string, Listing[]>();
+    for (const listing of listings ?? []) {
+      const bucket = listingsByFigure.get(listing.figure_id) ?? [];
+      bucket.push(listing as Listing);
+      listingsByFigure.set(listing.figure_id, bucket);
+    }
+
+    const userIds = unique(alerts.map((alert) => alert.user_id));
+
+    const { data: profiles, error: profileError } = await supabase
+      .from("user_profiles")
+      .select("user_id,preferences")
+      .in("user_id", userIds);
+
+    if (profileError) {
+      throw profileError;
+    }
+
+    const preferencesByUser = new Map(
+      (profiles ?? []).map((row) => [row.user_id, row.preferences])
+    );
+
+    const { data: tokens, error: tokenError } = await supabase
+      .from("push_tokens")
+      .select("user_id,expo_push_token")
+      .in("user_id", userIds);
+
+    if (tokenError) {
+      throw tokenError;
+    }
+
+    const tokensByUser = new Map<string, string[]>();
+    for (const token of tokens ?? []) {
+      if (!token.expo_push_token) {
+        continue;
+      }
+      const bucket = tokensByUser.get(token.user_id) ?? [];
+      bucket.push(token.expo_push_token);
+      tokensByUser.set(token.user_id, bucket);
+    }
+
+    const historyCache = new Map<string, HistoryPoint[]>();
+
+    async function getHistory(listingId: string) {
+      if (historyCache.has(listingId)) {
+        return historyCache.get(listingId) ?? [];
+      }
+      const { data, error } = await supabase
+        .from("price_history_points")
+        .select("price,currency,in_stock,captured_at")
+        .eq("retailer_listing_id", listingId)
+        .order("captured_at", { ascending: false })
+        .limit(2);
+      if (error) {
+        throw error;
+      }
+      const history = (data ?? []) as HistoryPoint[];
+      historyCache.set(listingId, history);
+      return history;
+    }
+
+    const messages: ExpoPushMessage[] = [];
+    const eventsToInsert: Array<Record<string, unknown>> = [];
+    let processed = 0;
+
+    for (const alert of alerts) {
+      processed += 1;
+      const userFigure = userFigureById.get(alert.user_figure_id);
+      const figureId = userFigure?.figure_id ?? null;
+      if (!figureId) {
+        continue;
+      }
+
+      const relevantListings = listingsByFigure.get(figureId) ?? [];
+      if (!relevantListings.length) {
+        continue;
+      }
+
+      const preferredRetailers = Array.isArray(alert.retailers)
+        ? alert.retailers
+        : [];
+      const candidateListings = preferredRetailers.length
+        ? relevantListings.filter((listing) =>
+            preferredRetailers.includes(listing.retailer)
+          )
+        : relevantListings;
+
+      if (!candidateListings.length) {
+        continue;
+      }
+
+      const priceCandidates: AlertCandidate[] = [];
+      const restockCandidates: AlertCandidate[] = [];
+      const targetPrice = toNumber(alert.target_price);
+      if (targetPrice === null) {
+        continue;
+      }
+
+      for (const listing of candidateListings) {
+        const history = await getHistory(listing.id);
+        if (history.length < 2) {
+          continue;
+        }
+        const [current, previous] = history;
+        const currentPrice = toNumber(current.price);
+        const previousPrice = toNumber(previous.price);
+        if (
+          currentPrice !== null &&
+          previousPrice !== null &&
+          currentPrice <= targetPrice &&
+          previousPrice > targetPrice
+        ) {
+          priceCandidates.push({
+            listing,
+            current: { ...current, price: currentPrice },
+            previous: { ...previous, price: previousPrice },
+          });
+        }
+
+        if (
+          alert.notify_on_restock &&
+          current.in_stock === true &&
+          previous.in_stock !== true
+        ) {
+          restockCandidates.push({ listing, current, previous });
+        }
+      }
+
+      let selected: { type: "price_drop" | "restock"; candidate: AlertCandidate } | null =
+        null;
+
+      if (priceCandidates.length) {
+        priceCandidates.sort((a, b) => a.current.price - b.current.price);
+        selected = { type: "price_drop", candidate: priceCandidates[0] };
+      } else if (restockCandidates.length) {
+        selected = { type: "restock", candidate: restockCandidates[0] };
+      }
+
+      if (!selected) {
+        continue;
+      }
+
+      const cooldownHours =
+        typeof alert.cooldown_hours === "number"
+          ? alert.cooldown_hours
+          : DEFAULT_COOLDOWN_HOURS;
+
+      const { data: lastEvents, error: lastEventError } = await supabase
+        .from("price_alert_events")
+        .select("triggered_at")
+        .eq("price_alert_id", alert.id)
+        .eq("event_type", selected.type)
+        .order("triggered_at", { ascending: false })
+        .limit(1);
+
+      if (lastEventError) {
+        throw lastEventError;
+      }
+
+      if (lastEvents?.length) {
+        const lastTriggered = new Date(lastEvents[0].triggered_at);
+        const nextAllowed = new Date(
+          lastTriggered.getTime() + cooldownHours * 60 * 60 * 1000
+        );
+        if (nextAllowed > now) {
+          continue;
+        }
+      }
+
+      const preferences = preferencesByUser.get(alert.user_id) ?? null;
+      const notificationPrefs =
+        (preferences?.notifications as Record<string, boolean> | undefined) ??
+        (preferences as Record<string, boolean> | null);
+      if (!shouldSendForPreferences(notificationPrefs, selected.type)) {
+        continue;
+      }
+
+      const userTokens = tokensByUser.get(alert.user_id) ?? [];
+      if (!userTokens.length) {
+        continue;
+      }
+
+      const figureName = figureNameById.get(figureId) ?? "Wishlist item";
+      const deeplink =
+        selected.type === "price_drop"
+          ? `/wishlist/details?userFigureId=${alert.user_figure_id}&figureId=${figureId}`
+          : `/wishlist?figureId=${figureId}`;
+
+      const eventPrice = toNumber(selected.candidate.current.price);
+      const priceText =
+        typeof eventPrice === "number" ? `${eventPrice.toFixed(2)}` : null;
+
+      const retailerLabel = selected.candidate.listing.retailer;
+
+      const title =
+        selected.type === "price_drop"
+          ? `${figureName} price drop`
+          : `${figureName} back in stock`;
+
+      const body =
+        selected.type === "price_drop"
+          ? `Now ${priceText ?? "available"} at ${retailerLabel}.`
+          : `Available at ${retailerLabel}.`;
+
+      for (const token of userTokens) {
+        messages.push({
+          to: token,
+          title,
+          body,
+          sound: "default",
+          data: {
+            type: selected.type,
+            figure_id: figureId,
+            user_figure_id: alert.user_figure_id,
+            deeplink,
+          },
+        });
+      }
+
+      eventsToInsert.push({
+        price_alert_id: alert.id,
+        user_id: alert.user_id,
+        user_figure_id: alert.user_figure_id,
+        retailer_listing_id: selected.candidate.listing.id,
+        event_type: selected.type,
+        price: eventPrice,
+        currency: selected.candidate.current.currency ?? alert.currency,
+        in_stock: selected.candidate.current.in_stock ?? null,
+        triggered_at: now.toISOString(),
+      });
+    }
+
+    if (messages.length) {
+      await sendExpoPushMessages(messages);
+    }
+
+    if (eventsToInsert.length) {
+      const { error: eventInsertError } = await supabase
+        .from("price_alert_events")
+        .insert(eventsToInsert);
+      if (eventInsertError) {
+        throw eventInsertError;
+      }
+    }
+
+    return jsonResponse({
+      ok: true,
+      alerts: alerts.length,
+      processed,
+      sent: messages.length,
+      events: eventsToInsert.length,
+    });
+  } catch (err) {
+    return jsonResponse(
+      { ok: false, error: err instanceof Error ? err.message : String(err) },
+      500
+    );
+  }
+});

--- a/supabase/functions/price-check/index.ts
+++ b/supabase/functions/price-check/index.ts
@@ -1,0 +1,147 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+import {
+  extractEbayItemId,
+  fetchEbayListing,
+} from "../_shared/retailers/ebay.ts";
+
+const DEFAULT_INTERVAL_HOURS = 6;
+const DEFAULT_BATCH_SIZE = 100;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function getAdminClient() {
+  const url = Deno.env.get("SUPABASE_URL");
+  const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!url || !key) {
+    throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.");
+  }
+  return createClient(url, key, {
+    auth: { persistSession: false },
+  });
+}
+
+function hoursAgo(hours: number) {
+  return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+}
+
+serve(async () => {
+  try {
+    const supabase = getAdminClient();
+    const intervalHours = Number(
+      Deno.env.get("PRICE_CHECK_INTERVAL_HOURS") ?? DEFAULT_INTERVAL_HOURS
+    );
+    const batchSize = Number(
+      Deno.env.get("PRICE_CHECK_BATCH_SIZE") ?? DEFAULT_BATCH_SIZE
+    );
+
+    const cutoff = hoursAgo(intervalHours);
+    const { data: listings, error } = await supabase
+      .from("retailer_listings")
+      .select("*")
+      .or(`last_checked_at.is.null,last_checked_at.lt.${cutoff}`)
+      .limit(batchSize);
+
+    if (error) {
+      throw error;
+    }
+
+    const now = new Date().toISOString();
+    const results = [] as Array<Record<string, unknown>>;
+    let updated = 0;
+    let skipped = 0;
+
+    for (const listing of listings ?? []) {
+      if (listing.retailer !== "EBAY") {
+        skipped += 1;
+        results.push({ id: listing.id, status: "skipped", reason: "retailer" });
+        continue;
+      }
+
+      const itemId = listing.external_id ?? extractEbayItemId(listing.product_url);
+      if (!itemId) {
+        skipped += 1;
+        results.push({
+          id: listing.id,
+          status: "skipped",
+          reason: "missing_external_id",
+        });
+        continue;
+      }
+
+      try {
+        const snapshot = await fetchEbayListing(itemId);
+        if (!snapshot) {
+          skipped += 1;
+          results.push({ id: listing.id, status: "skipped", reason: "not_found" });
+          continue;
+        }
+
+        const nextPrice = snapshot.price ?? listing.current_price ?? null;
+        const nextCurrency = snapshot.currency ?? listing.currency;
+        const nextInStock =
+          snapshot.inStock === null ? listing.in_stock : snapshot.inStock;
+
+        const { error: updateError } = await supabase
+          .from("retailer_listings")
+          .update({
+            current_price: nextPrice,
+            currency: nextCurrency,
+            in_stock: nextInStock,
+            last_checked_at: now,
+          })
+          .eq("id", listing.id);
+
+        if (updateError) {
+          throw updateError;
+        }
+
+        if (nextPrice !== null) {
+          const { error: historyError } = await supabase
+            .from("price_history_points")
+            .insert({
+              retailer_listing_id: listing.id,
+              price: nextPrice,
+              currency: nextCurrency,
+              in_stock: nextInStock,
+              captured_at: now,
+            });
+          if (historyError) {
+            throw historyError;
+          }
+        }
+
+        updated += 1;
+        results.push({ id: listing.id, status: "updated" });
+      } catch (err) {
+        skipped += 1;
+        results.push({
+          id: listing.id,
+          status: "error",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    return jsonResponse({
+      ok: true,
+      checked: listings?.length ?? 0,
+      updated,
+      skipped,
+      results,
+    });
+  } catch (err) {
+    return jsonResponse(
+      {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      500
+    );
+  }
+});

--- a/supabase/migrations/20260220000000_price_alert_events.sql
+++ b/supabase/migrations/20260220000000_price_alert_events.sql
@@ -1,0 +1,37 @@
+create table if not exists public.price_alert_events (
+  id uuid primary key default gen_random_uuid(),
+  price_alert_id uuid not null references public.price_alerts(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  user_figure_id uuid not null references public.user_figures(id) on delete cascade,
+  retailer_listing_id uuid references public.retailer_listings(id) on delete set null,
+  event_type text not null,
+  price numeric,
+  currency text,
+  in_stock boolean,
+  triggered_at timestamptz not null default now()
+);
+
+create index if not exists price_alert_events_alert_type_time_idx
+  on public.price_alert_events(price_alert_id, event_type, triggered_at desc);
+
+alter table public.price_alert_events enable row level security;
+
+create policy "Price alert events are viewable by owner"
+  on public.price_alert_events
+  for select
+  using (auth.uid() = user_id);
+
+create policy "Price alert events are insertable by owner"
+  on public.price_alert_events
+  for insert
+  with check (auth.uid() = user_id);
+
+create policy "Price alert events are updatable by owner"
+  on public.price_alert_events
+  for update
+  using (auth.uid() = user_id);
+
+create policy "Price alert events are deletable by owner"
+  on public.price_alert_events
+  for delete
+  using (auth.uid() = user_id);


### PR DESCRIPTION
Closes #19

Issue: https://github.com/jayvicsanantonio/force-collector/issues/19
Run: https://github.com/jayvicsanantonio/force-collector/actions/runs/22230178608

<details>
<summary>Codex summary</summary>

**What Changed**
- Added two Supabase Edge Functions implementing the scheduled jobs:
  - `supabase/functions/price-check/index.ts` polls stale `retailer_listings`, fetches eBay pricing, updates listing state, and inserts `price_history_points`.
  - `supabase/functions/alert-dispatch/index.ts` evaluates `price_alerts`, enforces cooldown via new `price_alert_events`, and sends Expo push notifications.
- Added eBay Browse API integration helper in `supabase/functions/_shared/retailers/ebay.ts`.
- Added `price_alert_events` table + RLS policies + index in `supabase/migrations/20260220000000_price_alert_events.sql`.
- Registered new functions in `supabase/config.toml`.

**How To Test**
1. `supabase start`
2. `supabase functions serve --env-file supabase/.env.local`
3. `curl -X POST http://localhost:54321/functions/v1/price-check`
4. `curl -X POST http://localhost:54321/functions/v1/alert-dispatch`

Environment needed for real eBay calls:
- `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`
- `EBAY_OAUTH_TOKEN` (required)
- `EBAY_MARKETPLACE_ID` (optional, defaults to `EBAY-US`)

**Limitations / Follow-ups**
1. Scheduling itself (cron) isn’t configured in-repo; you still need to wire Supabase scheduled triggers to call `price-check` and `alert-dispatch`.
2. Alerts won’t trigger until at least two `price_history_points` exist per listing (used for threshold/stock transitions).
3. Only eBay is implemented for MVP; other retailers are skipped.
</details>
