### PR TITLE
Codex: #21 [MVP] Implement Dashboard screen (summary, recent drops, hunt progress, FAB add)

### DIFF
--- a/apps/mobile/app/(modals)/add-figure.tsx
+++ b/apps/mobile/app/(modals)/add-figure.tsx
@@ -1,50 +1,99 @@
+import { Pressable, Text, View } from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
 import { router } from "expo-router";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { ScreenHeader } from "../../src/components/ScreenHeader";
+import { Card } from "../../src/components/Card";
+import { track } from "../../src/observability";
+
+const OPTIONS = [
+  {
+    id: "scan",
+    title: "Scan Barcode",
+    description: "Use the camera for instant matches.",
+    icon: "qr-code-scanner" as const,
+    route: "/search",
+  },
+  {
+    id: "manual",
+    title: "Manual Search",
+    description: "Search by name or enter a barcode.",
+    icon: "search" as const,
+    route: "/search/manual",
+  },
+  {
+    id: "custom",
+    title: "Custom Entry",
+    description: "Create a custom figure entry.",
+    icon: "edit" as const,
+    route: "/search/manual",
+  },
+];
 
 export default function AddFigureModal() {
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Add Figure</Text>
-      <Text style={styles.description}>
-        Placeholder for add figure flow (scan, manual, or custom).
-      </Text>
-      <Pressable style={styles.button} onPress={() => router.back()}>
-        <Text style={styles.buttonText}>Close</Text>
-      </Pressable>
+    <View className="flex-1 bg-void">
+      <ScreenHeader
+        title="Add Figure"
+        subtitle="Choose your entry method"
+        rightSlot={
+          <Pressable
+            onPress={() => router.back()}
+            accessibilityLabel="Close add figure"
+            className="h-10 w-10 items-center justify-center rounded-full border border-hud-line/70 bg-raised-surface/70"
+          >
+            <MaterialIcons name="close" size={18} color="#bae6fd" />
+          </Pressable>
+        }
+      />
+
+      <View className="flex-1 px-5 pb-8">
+        <View className="mt-6 gap-3">
+          {OPTIONS.map((option) => (
+            <Pressable
+              key={option.id}
+              onPress={() => {
+                track("add_figure_option_selected", { option: option.id });
+                router.replace(option.route);
+              }}
+            >
+              <Card className="flex-row items-center justify-between">
+                <View className="flex-row items-center gap-3">
+                  <View className="h-10 w-10 items-center justify-center rounded-full bg-raised-surface/80">
+                    <MaterialIcons
+                      name={option.icon}
+                      size={18}
+                      color="#22d3ee"
+                    />
+                  </View>
+                  <View>
+                    <Text className="text-sm font-space-semibold text-frost-text">
+                      {option.title}
+                    </Text>
+                    <Text className="text-xs text-secondary-text">
+                      {option.description}
+                    </Text>
+                  </View>
+                </View>
+                <MaterialIcons
+                  name="chevron-right"
+                  size={20}
+                  color="#94a3b8"
+                />
+              </Card>
+            </Pressable>
+          ))}
+        </View>
+
+        <View className="mt-6 rounded-2xl border border-hud-line/60 bg-raised-surface/60 px-4 py-3">
+          <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+            Tip
+          </Text>
+          <Text className="mt-2 text-xs text-secondary-text">
+            Scanning is the fastest way to add a figure, even when you are
+            offline.
+          </Text>
+        </View>
+      </View>
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 24,
-    backgroundColor: "#0b0f16",
-    justifyContent: "center",
-  },
-  title: {
-    color: "#e6f0ff",
-    fontSize: 24,
-    fontWeight: "700",
-  },
-  description: {
-    color: "#91a4c7",
-    marginTop: 12,
-    fontSize: 14,
-    lineHeight: 20,
-  },
-  button: {
-    marginTop: 24,
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    borderRadius: 10,
-    backgroundColor: "#1c2a3d",
-    borderWidth: 1,
-    borderColor: "#2f4566",
-  },
-  buttonText: {
-    color: "#e6f0ff",
-    fontSize: 14,
-    fontWeight: "600",
-  },
-});

--- a/apps/mobile/app/(tabs)/home/index.tsx
+++ b/apps/mobile/app/(tabs)/home/index.tsx
@@ -1,168 +1,305 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
-import { router, useLocalSearchParams } from "expo-router";
+import { BlurView } from "expo-blur";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { router } from "expo-router";
+import { Avatar } from "../../../src/components/Avatar";
+import { Badge } from "../../../src/components/Badge";
 import { Button } from "../../../src/components/Button";
 import { Card } from "../../../src/components/Card";
-import { Chip } from "../../../src/components/Chip";
-import { Badge } from "../../../src/components/Badge";
-import { ScreenHeader } from "../../../src/components/ScreenHeader";
 import { StatCard } from "../../../src/components/StatCard";
-import { Avatar } from "../../../src/components/Avatar";
-import { useTheme } from "../../../src/theme/ThemeProvider";
-import { useDashboardSummary } from "../../../src/offline/hooks";
 import { useOfflineStatus } from "../../../src/offline/OfflineProvider";
+import { useDashboardSummary, useRecentFigures } from "../../../src/offline/hooks";
+import type { CachedFigure, FigureStatus } from "../../../src/offline/types";
+import { useTheme } from "../../../src/theme/ThemeProvider";
+import { cx } from "../../../src/utils/cx";
 import { track } from "../../../src/observability";
 
+const RECENT_DROPS_LIMIT = 6;
+
+const STATUS_BADGE: Record<
+  FigureStatus,
+  { label: string; tone: "owned" | "wishlist" | "limited" | "neutral" }
+> = {
+  OWNED: { label: "Owned", tone: "owned" },
+  WISHLIST: { label: "Wishlist", tone: "wishlist" },
+  PREORDER: { label: "Pre-order", tone: "limited" },
+  SOLD: { label: "Sold", tone: "neutral" },
+};
+
+function formatCurrency(value: number) {
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    }).format(value);
+  } catch {
+    return `$${Math.round(value)}`;
+  }
+}
+
+function getDropLabel(item: CachedFigure) {
+  return STATUS_BADGE[item.status] ?? STATUS_BADGE.WISHLIST;
+}
+
 export default function HomeScreen() {
-  const { allegiance, toggleAllegiance, accentTextClass } = useTheme();
-  const summary = useDashboardSummary();
+  const { summary, loading: summaryLoading, refreshing } =
+    useDashboardSummary();
+  const { data: recentDrops, loading: recentLoading } = useRecentFigures(
+    RECENT_DROPS_LIMIT
+  );
   const { isOnline } = useOfflineStatus();
-  const params = useLocalSearchParams<{
-    highlight?: string;
-    figureId?: string;
-  }>();
+  const { accentTextClass } = useTheme();
 
   useEffect(() => {
     track("dashboard_viewed");
   }, []);
 
+  const completionLabel = `${Math.round(summary.completionPercent)}%`;
+  const estimatedValueLabel = formatCurrency(summary.estimatedValue);
+
+  const huntGoal = useMemo(() => {
+    const total = summary.totalOwned + summary.totalWishlist;
+    if (total === 0) {
+      return {
+        name: "Starter Wave",
+        target: 12,
+        completed: 0,
+      };
+    }
+    return {
+      name: "Wishlist Sweep",
+      target: Math.max(total, 12),
+      completed: summary.totalOwned,
+    };
+  }, [summary.totalOwned, summary.totalWishlist]);
+
+  const huntProgress =
+    huntGoal.target > 0
+      ? Math.min(huntGoal.completed / huntGoal.target, 1)
+      : 0;
+
   return (
     <View className="flex-1 bg-void">
-      <ScreenHeader
-        title="Design System"
-        subtitle={`Allegiance: ${allegiance.toUpperCase()} · ${
-          isOnline ? "Online" : "Offline"
-        }`}
-        rightSlot={
-          <Button
-            label="Toggle"
-            variant="ghost"
-            onPress={toggleAllegiance}
-          />
-        }
-      />
-      <ScrollView className="flex-1" contentContainerStyle={styles.content}>
-        <View className="gap-6">
-          {(params.highlight || params.figureId) && (
-            <View className="rounded-2xl border border-hud-line/60 bg-raised-surface/70 px-4 py-3">
-              <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
-                Notification
-              </Text>
-              <Text className="mt-2 text-sm text-frost-text">
-                Opened for {params.highlight ?? params.figureId}.
-              </Text>
-            </View>
-          )}
-          <View>
-            <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
-              Buttons
-            </Text>
-            <View className="mt-3 gap-3">
-              <Button
-                label="Primary Action"
-                onPress={() => track("dashboard_fab_tapped")}
-              />
-              <Button label="Secondary Action" variant="secondary" />
-              <Button label="Ghost Action" variant="ghost" />
-              <Button label="Loading" loading />
-            </View>
-          </View>
-
-          <View>
-            <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
-              Cards & Stats
-            </Text>
-            <View className="mt-3 gap-3">
-              <Pressable onPress={() => track("dashboard_recent_drop_opened")}>
-                <Card>
-                  <Text className="text-sm font-space-semibold text-frost-text">
-                    HUD Card Surface
+      <SafeAreaView edges={["top"]} className="bg-void">
+        <BlurView intensity={40} tint="dark" style={styles.headerBlur}>
+          <View className="flex-row items-center justify-between">
+            <View className="flex-row items-center gap-3">
+              <Avatar size="md" label="FC" />
+              <View>
+                <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+                  Welcome back
+                </Text>
+                <View className="flex-row items-center gap-2">
+                  <Text className="text-lg font-space-bold text-frost-text">
+                    Force Collector
                   </Text>
-                  <Text className="mt-2 text-xs text-secondary-text">
-                    Dark slate surfaces with border lines and cyan accents.
-                  </Text>
-                </Card>
-              </Pressable>
-              <View className="flex-row gap-3">
-                <View className="flex-1">
-                  <StatCard
-                    label="Owned"
-                    value={summary.totalOwned.toString()}
-                    helper={`${summary.pendingSync} pending sync`}
-                  />
-                </View>
-                <View className="flex-1">
-                  <StatCard
-                    label="Wishlist"
-                    value={summary.totalWishlist.toString()}
-                    helper="Cached"
-                  />
+                  {!isOnline ? (
+                    <Badge label="Offline" tone="neutral" iconName="cloud-off" />
+                  ) : null}
                 </View>
               </View>
             </View>
+            <Pressable
+              onPress={() => {
+                track("dashboard_settings_tapped");
+                router.push("/profile/settings");
+              }}
+              accessibilityLabel="Open settings"
+              className="h-10 w-10 items-center justify-center rounded-full border border-hud-line/70 bg-raised-surface/70"
+            >
+              <MaterialIcons name="settings" size={18} color="#bae6fd" />
+            </Pressable>
           </View>
+        </BlurView>
+      </SafeAreaView>
 
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        <View className="gap-6">
           <View>
             <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
-              Chips
+              Summary
             </Text>
-            <View className="mt-3 flex-row flex-wrap gap-2">
-              <Chip label="All" selected />
-              <Chip label="Favorites" />
-              <Chip label="Rare" />
-              <Chip label="Clone Wars" />
+            <View className="mt-3 flex-row gap-3">
+              <View
+                className="flex-1"
+                accessible
+                accessibilityLabel={`Total figures: ${summary.totalOwned}`}
+              >
+                {summaryLoading ? (
+                  <View className="h-[88px] rounded-2xl border border-hud-line/60 bg-raised-surface/70" />
+                ) : (
+                  <StatCard
+                    label="Total Figs"
+                    value={summary.totalOwned.toString()}
+                    helper={
+                      summary.pendingSync > 0
+                        ? `${summary.pendingSync} pending sync`
+                        : isOnline
+                          ? "Synced"
+                          : "Cached"
+                    }
+                  />
+                )}
+              </View>
+              <View
+                className="flex-1"
+                accessible
+                accessibilityLabel={`Estimated value: ${estimatedValueLabel}`}
+              >
+                {summaryLoading ? (
+                  <View className="h-[88px] rounded-2xl border border-hud-line/60 bg-raised-surface/70" />
+                ) : (
+                  <StatCard
+                    label="Value"
+                    value={estimatedValueLabel}
+                    helper={refreshing ? "Refreshing" : "Estimate"}
+                  />
+                )}
+              </View>
+            </View>
+            <View
+              className="mt-3"
+              accessible
+              accessibilityLabel={`Completion: ${completionLabel}`}
+            >
+              {summaryLoading ? (
+                <View className="h-[88px] rounded-2xl border border-hud-line/60 bg-raised-surface/70" />
+              ) : (
+                <StatCard
+                  label="Completion"
+                  value={completionLabel}
+                  helper={huntGoal.name}
+                />
+              )}
             </View>
           </View>
 
           <View>
-            <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
-              Badges
-            </Text>
-            <View className="mt-3 flex-row flex-wrap gap-2">
-              <Badge label="Owned" tone="owned" />
-              <Badge label="Wishlist" tone="wishlist" />
-              <Badge label="Exclusive" tone="exclusive" />
-              <Badge label="In Stock" tone="in-stock" />
-              <Badge label="Limited" tone="limited" />
-            </View>
-            <Text className="mt-2 text-[11px] text-muted-text">
-              Status uses icon + text in addition to color.
-            </Text>
-          </View>
-
-          <View>
-            <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
-              Avatar
-            </Text>
-            <View className="mt-3 flex-row items-center gap-3">
-              <Avatar size="sm" label="FC" />
-              <Avatar size="md" label="JS" />
-              <Avatar size="lg" label="LS" />
-            </View>
-          </View>
-
-          <View>
-            <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
-              Accent Preview
-            </Text>
-            <View className="mt-3 flex-row items-center gap-2 rounded-2xl border border-hud-line/60 bg-raised-surface/70 px-4 py-3">
-              <MaterialIcons
-                name="flash-on"
-                size={18}
-                color={allegiance === "light" ? "#2e86c1" : "#c0392b"}
-              />
-              <Text className={`text-sm font-space-medium ${accentTextClass}`}>
-                Allegiance accent updates instantly.
+            <View className="flex-row items-center justify-between">
+              <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+                Recent Drops
               </Text>
+              <Pressable
+                onPress={() => {
+                  track("dashboard_recent_view_all");
+                  router.push("/search");
+                }}
+              >
+                <Text
+                  className={cx(
+                    "text-xs font-space-semibold uppercase tracking-widest",
+                    accentTextClass
+                  )}
+                >
+                  View All
+                </Text>
+              </Pressable>
             </View>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.horizontalContent}
+            >
+              {recentLoading
+                ? Array.from({ length: 3 }).map((_, index) => (
+                    <View
+                      key={`recent-skeleton-${index}`}
+                      className="h-[170px] w-[180px] rounded-2xl border border-hud-line/60 bg-raised-surface/70"
+                    />
+                  ))
+                : recentDrops.length > 0
+                  ? recentDrops.map((item) => {
+                      const badge = getDropLabel(item);
+                      return (
+                        <Pressable
+                          key={item.id}
+                          onPress={() => {
+                            track("dashboard_recent_drop_opened");
+                            router.push({
+                              pathname: "/collection/details",
+                              params: {
+                                userFigureId: item.id,
+                                source: "dashboard",
+                              },
+                            });
+                          }}
+                        >
+                          <Card className="h-[170px] w-[180px] justify-between">
+                            <View className="gap-2">
+                              <Text
+                                className="text-sm font-space-semibold text-frost-text"
+                                numberOfLines={2}
+                              >
+                                {item.name}
+                              </Text>
+                              <Text
+                                className="text-xs font-space-medium text-secondary-text"
+                                numberOfLines={1}
+                              >
+                                {item.series ?? "Unknown series"}
+                              </Text>
+                              <Badge label={badge.label} tone={badge.tone} />
+                            </View>
+                            <View>
+                              <Text className="text-xs font-space-medium text-secondary-text">
+                                {item.lastPrice !== null && item.lastPrice !== undefined
+                                  ? formatCurrency(item.lastPrice)
+                                  : "Value pending"}
+                              </Text>
+                              <Text className="text-[10px] font-space-semibold uppercase tracking-widest text-muted-text">
+                                Updated {new Date(item.updatedAt).toLocaleDateString()}
+                              </Text>
+                            </View>
+                          </Card>
+                        </Pressable>
+                      );
+                    })
+                  : (
+                      <Card className="h-[170px] w-[260px] justify-between">
+                        <View className="gap-2">
+                          <Text className="text-sm font-space-semibold text-frost-text">
+                            No drops yet
+                          </Text>
+                          <Text className="text-xs text-secondary-text">
+                            Scan a figure to start tracking releases.
+                          </Text>
+                        </View>
+                        <Button
+                          label="Start Scanning"
+                          variant="secondary"
+                          onPress={() => router.push("/search")}
+                        />
+                      </Card>
+                    )}
+            </ScrollView>
           </View>
 
           <View>
             <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
-              Dashboard Actions
+              Hunt Progress
             </Text>
-            <View className="mt-3 gap-3">
+            <Card className="mt-3 gap-4">
+              <View className="gap-1">
+                <Text className="text-sm font-space-semibold text-frost-text">
+                  {huntGoal.name}
+                </Text>
+                <Text className="text-xs text-secondary-text">
+                  {huntGoal.completed} / {huntGoal.target} collected
+                </Text>
+              </View>
+              <View className="h-2 w-full rounded-full bg-raised-surface">
+                <View
+                  style={{ width: `${Math.round(huntProgress * 100)}%` }}
+                  className="h-2 rounded-full bg-bright-cyan"
+                />
+              </View>
               <Button
                 label="View Wishlist"
                 variant="secondary"
@@ -171,22 +308,51 @@ export default function HomeScreen() {
                   router.push("/wishlist");
                 }}
               />
-              <Button
-                label="Open Recent Drop"
-                variant="ghost"
-                onPress={() => track("dashboard_recent_drop_opened")}
-              />
-              <Button
-                label="Add Figure"
-                onPress={() => {
-                  track("dashboard_fab_tapped");
-                  router.push("/add-figure");
-                }}
-              />
-            </View>
+            </Card>
+          </View>
+
+          <View>
+            <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+              New Drop
+            </Text>
+            <Pressable
+              onPress={() => {
+                track("dashboard_promo_opened");
+                router.push("/search");
+              }}
+            >
+              <Card className="mt-3 gap-2 border border-cyan-500/40 bg-raised-surface/70">
+                <Text className="text-sm font-space-semibold text-frost-text">
+                  Archive Wave Incoming
+                </Text>
+                <Text className="text-xs text-secondary-text">
+                  Reserve the latest wave and set alerts for price drops.
+                </Text>
+                <View className="flex-row items-center gap-2">
+                  <MaterialIcons name="bolt" size={16} color="#22d3ee" />
+                  <Text className="text-xs font-space-semibold uppercase tracking-widest text-bright-cyan">
+                    Pre-order watchlist
+                  </Text>
+                </View>
+              </Card>
+            </Pressable>
           </View>
         </View>
       </ScrollView>
+
+      <Pressable
+        onPress={() => {
+          track("dashboard_fab_tapped");
+          router.push("/add-figure");
+        }}
+        accessibilityLabel="Add figure"
+        className="absolute"
+        style={styles.fab}
+      >
+        <View className="h-14 w-14 items-center justify-center rounded-full bg-bright-cyan">
+          <MaterialIcons name="add" size={28} color="#020617" />
+        </View>
+      </Pressable>
     </View>
   );
 }
@@ -195,6 +361,23 @@ const styles = StyleSheet.create({
   content: {
     paddingHorizontal: 20,
     paddingTop: 24,
-    paddingBottom: 40,
+    paddingBottom: 120,
+  },
+  horizontalContent: {
+    paddingTop: 12,
+    paddingBottom: 8,
+    gap: 12,
+    paddingRight: 20,
+  },
+  headerBlur: {
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(30,58,138,0.6)",
+    backgroundColor: "rgba(2,6,23,0.7)",
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+  },
+  fab: {
+    right: 20,
+    bottom: 90,
   },
 });

--- a/apps/mobile/src/offline/types.ts
+++ b/apps/mobile/src/offline/types.ts
@@ -62,4 +62,6 @@ export type DashboardSummary = {
   totalOwned: number;
   totalWishlist: number;
   pendingSync: number;
+  estimatedValue: number;
+  completionPercent: number;
 };


### PR DESCRIPTION
Closes #21

Issue: https://github.com/jayvicsanantonio/force-collector/issues/21
Run: https://github.com/jayvicsanantonio/force-collector/actions/runs/22279786048

<details>
<summary>Codex summary</summary>

**What Changed**
- Replaced the Home tab with the Dashboard layout: header (avatar + settings), summary stats, recent drops carousel, hunt progress card, promo tile, and FAB.
- Added cached dashboard summary support with estimated value and completion percent, plus a recent figures hook for the carousel.
- Updated the Add Figure modal to present scan/manual/custom options and route accordingly.

**How To Test**
```bash
cd /home/runner/work/force-collector/force-collector/apps/mobile
npm run start
```
1. Open the Home tab to confirm stats, recent drops, and hunt progress render.
2. Tap a recent drop to confirm it routes to figure details.
3. Tap View Wishlist, Settings, and the FAB to confirm each routes properly.

**Limitations / Follow-ups**
- Recent Drops currently use the most recently updated local figures (no remote drops feed yet).
- Completion percent and hunt progress are derived from owned + wishlist counts; configurable goals are not implemented.
- Custom entry currently routes to manual search (no dedicated custom entry flow yet).

Tests were not run (no automated test scripts available).
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned Add Figure modal with organized entry methods and helpful tips
  * Home screen redesigned with summary stats, hunt progress tracking, and recent drops section
  * Floating action button for quick figure addition
  * Enhanced header with avatar, online status badge, and settings access
  * Improved offline support with data caching and sync status indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->