### PR TITLE
Codex: #26 [MVP] Implement Achievements + XP/Level system + Achievements list screen

### DIFF
--- a/apps/mobile/app/(tabs)/profile/achievements.tsx
+++ b/apps/mobile/app/(tabs)/profile/achievements.tsx
@@ -1,49 +1,37 @@
+import { MaterialIcons } from "@expo/vector-icons";
 import { Text, View } from "react-native";
 import PlaceholderScreen from "../../../src/PlaceholderScreen";
+import { useMe } from "../../../src/api/me";
 import { Badge } from "../../../src/components/Badge";
-
-const ACHIEVEMENTS = [
-  {
-    key: "first_scan",
-    title: "First Scan",
-    description: "Logged your first figure.",
-    unlocked: true,
-  },
-  {
-    key: "holocron_keeper",
-    title: "Holocron Keeper",
-    description: "Cataloged 25 collectibles.",
-    unlocked: true,
-  },
-  {
-    key: "fleet_commander",
-    title: "Fleet Commander",
-    description: "Tracked 5 rare variants.",
-    unlocked: true,
-  },
-  {
-    key: "master_collector",
-    title: "Master Collector",
-    description: "Completed a wave.",
-    unlocked: false,
-  },
-];
+import { useTheme } from "../../../src/theme/ThemeProvider";
 
 export default function AchievementsScreen() {
+  const { data, isLoading } = useMe();
+  const { accentBgClass } = useTheme();
+  const achievements = data?.achievements.items ?? [];
+
   return (
     <PlaceholderScreen
       title="Achievements"
-      description="Unlocked milestones from your collecting journey."
+      description="All milestones and your unlock progress."
     >
-      {ACHIEVEMENTS.map((achievement) => (
+      {isLoading ? (
+        <Text className="text-xs text-secondary-text">Syncing achievements...</Text>
+      ) : null}
+      {achievements.map((achievement) => (
         <View
           key={achievement.key}
           className="rounded-2xl border border-hud-line/60 bg-hud-surface p-4"
         >
           <View className="flex-row items-center justify-between">
-            <Text className="text-sm font-space-semibold text-frost-text">
-              {achievement.title}
-            </Text>
+            <View className="flex-1 flex-row items-center gap-2">
+              <View className={accentBgClass + " h-8 w-8 items-center justify-center rounded-full"}>
+                <MaterialIcons name={achievement.icon as never} size={16} color="#f8fafc" />
+              </View>
+              <Text className="flex-1 text-sm font-space-semibold text-frost-text">
+                {achievement.title}
+              </Text>
+            </View>
             <Badge
               label={achievement.unlocked ? "Unlocked" : "Locked"}
               tone={achievement.unlocked ? "owned" : "neutral"}
@@ -52,8 +40,36 @@ export default function AchievementsScreen() {
           <Text className="mt-2 text-xs text-secondary-text">
             {achievement.description}
           </Text>
+          <View className="mt-3">
+            <View className="flex-row items-center justify-between">
+              <Text className="text-[11px] font-space-semibold uppercase tracking-widest text-secondary-text">
+                Progress
+              </Text>
+              <Text className="text-[11px] text-secondary-text">
+                {achievement.progress_label}
+              </Text>
+            </View>
+            <View className="mt-2 h-2 overflow-hidden rounded-full bg-profile-panel">
+              <View
+                className={accentBgClass + " h-2 rounded-full"}
+                style={{
+                  width: `${Math.min(
+                    100,
+                    Math.round(
+                      (achievement.progress_current / achievement.progress_target) * 100
+                    )
+                  )}%`,
+                }}
+              />
+            </View>
+          </View>
         </View>
       ))}
+      {!isLoading && !achievements.length ? (
+        <Text className="text-xs text-secondary-text">
+          No achievements configured yet.
+        </Text>
+      ) : null}
     </PlaceholderScreen>
   );
 }

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  AchievementSchema,
   CollectionSummarySchema,
   DistributionBreakdownSchema,
   FigureSchema,
@@ -30,6 +31,27 @@ export type AnalyticsDistributionBy = z.infer<typeof AnalyticsDistributionBySche
 export const MeResponseSchema = z.object({
   user: UserSchema,
   profile: UserProfileSchema,
+  achievements: z.object({
+    items: z.array(
+      AchievementSchema.extend({
+        unlocked: z.boolean(),
+        unlocked_at: z.string().datetime().nullable(),
+        progress_current: z.number().int().nonnegative(),
+        progress_target: z.number().int().positive(),
+        progress_label: z.string(),
+      })
+    ),
+    unlocked_count: z.number().int().nonnegative(),
+    total_count: z.number().int().nonnegative(),
+  }),
+  progression: z.object({
+    level: z.number().int().min(1),
+    total_xp: z.number().int().nonnegative(),
+    xp_in_level: z.number().int().nonnegative(),
+    xp_for_next_level: z.number().int().positive(),
+    current_level_total_xp: z.number().int().nonnegative(),
+    next_level_total_xp: z.number().int().positive(),
+  }),
 });
 export type MeResponse = z.infer<typeof MeResponseSchema>;
 

--- a/supabase/migrations/20260224000000_achievements_mvp.sql
+++ b/supabase/migrations/20260224000000_achievements_mvp.sql
@@ -1,0 +1,16 @@
+-- MVP achievements set for profile progression (Issue #26).
+
+delete from public.achievements
+where key in ('first-figure', 'wishlist-starter');
+
+insert into public.achievements (key, title, description, icon)
+values
+  ('first_scan', 'First Scan', 'Log your first owned figure.', 'qr-code-scanner'),
+  ('ten_owned', 'Collector I', 'Own 10 figures.', 'inventory-2'),
+  ('wave_complete', 'Wave Hunter', 'Complete any figure wave.', 'emoji-events'),
+  ('first_price_alert', 'Price Sentinel', 'Create your first price alert.', 'notifications-active')
+on conflict (key)
+do update set
+  title = excluded.title,
+  description = excluded.description,
+  icon = excluded.icon;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -43,6 +43,8 @@ insert into public.figures (
 
 insert into public.achievements (key, title, description, icon)
 values
-  ('first-figure', 'First Figure', 'Add your first figure to the collection.', 'trophy'),
-  ('wishlist-starter', 'Wishlist Starter', 'Add your first wishlist item.', 'star')
+  ('first_scan', 'First Scan', 'Log your first owned figure.', 'qr-code-scanner'),
+  ('ten_owned', 'Collector I', 'Own 10 figures.', 'inventory-2'),
+  ('wave_complete', 'Wave Hunter', 'Complete any figure wave.', 'emoji-events'),
+  ('first_price_alert', 'Price Sentinel', 'Create your first price alert.', 'notifications-active')
 on conflict (key) do nothing;


### PR DESCRIPTION
Closes #26

Issue: https://github.com/jayvicsanantonio/force-collector/issues/26
Run: https://github.com/jayvicsanantonio/force-collector/actions/runs/22492522328

<details>
<summary>Codex summary</summary>

Implemented Issue #26 in a scoped way across backend + mobile profile screens.

**What changed**

1. Backend achievements + XP/level computation
- Added `/v1/me` `GET` and `PATCH` handlers in [supabase/functions/api/index.ts](/home/runner/work/force-collector/force-collector/supabase/functions/api/index.ts).
- `GET /v1/me` now:
  - Ensures `user_profiles` row exists.
  - Loads achievement catalog + user unlocks.
  - Applies documented unlock rules:
    - `first_scan`: own at least 1 figure
    - `ten_owned`: own at least 10 figures
    - `wave_complete`: own all figures in any wave
    - `first_price_alert`: create at least 1 price alert
  - Persists new unlocks into `user_achievements`.
  - Computes deterministic XP + level from activity and unlocked achievements.
  - Returns `user`, `profile`, `achievements` (with lock/progress), and `progression`.

2. Shared API contract updates
- Extended `MeResponseSchema` with `achievements` and `progression` in [packages/shared/src/api.ts](/home/runner/work/force-collector/force-collector/packages/shared/src/api.ts).

3. Seed/migration for MVP achievement set
- Updated seed achievement keys/data in [supabase/seed.sql](/home/runner/work/force-collector/force-collector/supabase/seed.sql).
- Added migration to upsert MVP achievements (and remove old placeholder keys) in [supabase/migrations/20260224000000_achievements_mvp.sql](/home/runner/work/force-collector/force-collector/supabase/migrations/20260224000000_achievements_mvp.sql).

4. Profile carousel + View All screen wired to backend data
- Profile now uses backend unlock state and computed progression in [apps/mobile/app/(tabs)/profile/index.tsx](/home/runner/work/force-collector/force-collector/apps/mobile/app/(tabs)/profile/index.tsx).
- Achievements “View All” now lists all achievements with lock state and progress bars in [apps/mobile/app/(tabs)/profile/achievements.tsx](/home/runner/work/force-collector/force-collector/apps/mobile/app/(tabs)/profile/achievements.tsx).

**How to test (commands)**

1. Apply DB changes:
```bash
supabase db reset
# or run migration in your normal pipeline/env
```

2. Run mobile app:
```bash
cd apps/mobile
npm install
npm run start
```

3. Verify acceptance behavior manually:
- Open Profile:
  - Achievements carousel should show only unlocked achievements from backend.
  - XP/level should come from backend progression.
- Tap `View All`:
  - Should list all achievements with correct locked/unlocked state and progress bars.
- Trigger unlock conditions (own first figure, 10 owned, complete a wave, create first price alert) and re-open Profile/Achievements to confirm updates.

**Limitations / follow-ups**

- I could not run full typecheck/tests in this runner due environment/tooling limits (`npm` cache permission issues initially, no local TS install, no `deno` binary).  
- XP is currently computed server-side from owned count + unlocked achievements (deterministic curve), not persisted as authoritative DB fields.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a dynamic achievement system with progress tracking for First Scan, Ten Owned, Wave Complete, and First Price Alert
  * Added XP-based progression and leveling system
  * Profile page now displays achievements with progress bars, loading indicators, and unlock status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->