### PR TITLE
[codex] Fix data contracts, hydration, and manual entry flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,6 @@ npm run web      # Start in browser
 
 ## Testing
 
-There are currently no committed unit/integration test suites or `npm test` script in `apps/mobile`.
-
 Current practical testing workflow:
 
 1. Type check:
@@ -191,15 +189,20 @@ Current practical testing workflow:
    cd apps/mobile
    npx expo-doctor
    ```
-3. Backend health smoke check:
+3. Contract checks:
+   ```bash
+   node --experimental-specifier-resolution=node --test tests/contracts/api-contracts.test.mjs
+   ```
+4. Backend health smoke check:
    ```bash
    supabase functions serve health --env-file .env
    curl http://127.0.0.1:54321/functions/v1/health
    ```
-4. Manual feature validation on at least one simulator/emulator and one real phone.
+5. Manual feature validation on at least one simulator/emulator and one real phone.
 
 For full, step-by-step QA instructions, use:
 - [`docs/mobile-run-test-guide.md`](docs/mobile-run-test-guide.md)
+- [`docs/mobile-data-flow.md`](docs/mobile-data-flow.md)
 
 ## Simulator, Emulator, and Physical Device
 

--- a/apps/mobile/app/(modals)/add-figure.tsx
+++ b/apps/mobile/app/(modals)/add-figure.tsx
@@ -25,7 +25,7 @@ const OPTIONS = [
     title: "Custom Entry",
     description: "Create a custom figure entry.",
     icon: "edit" as const,
-    route: "/search/manual",
+    route: "/search/manual?mode=custom",
   },
 ];
 

--- a/apps/mobile/app/(tabs)/search/manual.tsx
+++ b/apps/mobile/app/(tabs)/search/manual.tsx
@@ -1,10 +1,392 @@
-import PlaceholderScreen from "../../../src/PlaceholderScreen";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
+import { router, useLocalSearchParams } from "expo-router";
+import { Button } from "../../../src/components/Button";
+import { Card } from "../../../src/components/Card";
+import { ScreenHeader } from "../../../src/components/ScreenHeader";
+import { createUserFigure, updateUserFigureStatus } from "../../../src/api/user-figures";
+import { useFigureSearch } from "../../../src/api/figures";
+import { useOfflineStatus } from "../../../src/offline/OfflineProvider";
+import {
+  applyServerUpdate,
+  getFigureByFigureId,
+} from "../../../src/offline/cache";
+import {
+  useUpdateFigureStatus,
+  useUpsertFigureRecord,
+} from "../../../src/offline/hooks";
+import type { FigureStatus } from "../../../src/offline/types";
+import { track } from "../../../src/observability";
+
+type Mode = "search" | "custom";
+
+const STATUS_OPTIONS: Array<{ value: FigureStatus; label: string }> = [
+  { value: "OWNED", label: "Add to Collection" },
+  { value: "WISHLIST", label: "Add to Wishlist" },
+];
+
+function normalizeMode(value: string | undefined): Mode {
+  return value === "custom" ? "custom" : "search";
+}
 
 export default function ManualLookupScreen() {
+  const params = useLocalSearchParams<{ mode?: string }>();
+  const initialMode = normalizeMode(params.mode);
+  const { isOnline } = useOfflineStatus();
+  const updateStatusOffline = useUpdateFigureStatus();
+  const upsertFigure = useUpsertFigureRecord();
+  const [mode, setMode] = useState<Mode>(initialMode);
+  const [query, setQuery] = useState("");
+  const [customName, setCustomName] = useState("");
+  const [customSeries, setCustomSeries] = useState("");
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmedQuery = query.trim();
+  const searchQuery = useFigureSearch(trimmedQuery);
+  const searchResults = searchQuery.data?.items ?? [];
+
+  useEffect(() => {
+    setMode(initialMode);
+  }, [initialMode]);
+
+  useEffect(() => {
+    track("manual_search_viewed", { mode });
+  }, [mode]);
+
+  const resetFeedback = useCallback(() => {
+    setNotice(null);
+    setError(null);
+  }, []);
+
+  const createOrUpdateFigure = useCallback(
+    async (
+      input: {
+        figureId?: string | null;
+        name: string;
+        series?: string | null;
+        customPayload?: Record<string, unknown>;
+      },
+      status: FigureStatus
+    ) => {
+      resetFeedback();
+      const pendingKey = input.figureId ?? input.name;
+      setPendingId(pendingKey);
+
+      try {
+        const existing = input.figureId
+          ? await getFigureByFigureId(input.figureId)
+          : null;
+
+        if (existing) {
+          if (existing.status === status) {
+            setNotice(
+              status === "OWNED"
+                ? "Already in your collection."
+                : "Already on your wishlist."
+            );
+            return;
+          }
+
+          if (isOnline) {
+            const response = await updateUserFigureStatus(existing.id, status);
+            await applyServerUpdate(
+              existing.id,
+              status,
+              response.updated_at ?? new Date().toISOString()
+            );
+          } else {
+            await updateStatusOffline(existing.id, status);
+          }
+
+          setNotice(
+            status === "OWNED"
+              ? "Moved to your collection."
+              : "Moved to your wishlist."
+          );
+          return;
+        }
+
+        if (!isOnline) {
+          setError("Manual search and custom entry require a connection right now.");
+          return;
+        }
+
+        const response = await createUserFigure({
+          figure_id: input.figureId ?? undefined,
+          custom_figure_payload: input.customPayload,
+          status,
+          condition: "UNKNOWN",
+        });
+
+        await upsertFigure({
+          id: response.id,
+          figureId: response.figure_id ?? input.figureId ?? null,
+          name: input.name,
+          series: input.series ?? null,
+          status,
+          updatedAt: response.updated_at ?? new Date().toISOString(),
+          syncPending: false,
+        });
+
+        setNotice(
+          status === "OWNED"
+            ? "Added to your collection."
+            : "Added to your wishlist."
+        );
+
+        if (!input.figureId) {
+          setCustomName("");
+          setCustomSeries("");
+        }
+      } catch (createError) {
+        setError(
+          createError instanceof Error
+            ? createError.message
+            : "Unable to save this figure."
+        );
+      } finally {
+        setPendingId(null);
+      }
+    },
+    [customName, customSeries, isOnline, resetFeedback, updateStatusOffline, upsertFigure]
+  );
+
+  const customPayload = useMemo(() => {
+    const name = customName.trim();
+    const series = customSeries.trim();
+    if (!name) {
+      return null;
+    }
+    return {
+      name,
+      ...(series ? { series } : {}),
+    };
+  }, [customName, customSeries]);
+
   return (
-    <PlaceholderScreen
-      title="Manual Lookup"
-      description="Placeholder for manual search and barcode entry."
-    />
+    <View className="flex-1 bg-void">
+      <ScreenHeader
+        title="Manual Search"
+        subtitle={mode === "custom" ? "Create a custom figure" : "Search the catalog"}
+        rightSlot={
+          <Pressable
+            onPress={() => router.back()}
+            className="rounded-full border border-hud-line/70 bg-raised-surface/70 px-3 py-1"
+          >
+            <Text className="text-[10px] font-space-semibold uppercase tracking-widest text-secondary-text">
+              Close
+            </Text>
+          </Pressable>
+        }
+      />
+
+      <ScrollView contentContainerStyle={styles.content}>
+        <View className="flex-row gap-3">
+          <View className="flex-1">
+            <Button
+              label="Search Catalog"
+              variant={mode === "search" ? "primary" : "secondary"}
+              onPress={() => {
+                resetFeedback();
+                setMode("search");
+              }}
+            />
+          </View>
+          <View className="flex-1">
+            <Button
+              label="Custom Entry"
+              variant={mode === "custom" ? "primary" : "secondary"}
+              onPress={() => {
+                resetFeedback();
+                setMode("custom");
+              }}
+            />
+          </View>
+        </View>
+
+        {!isOnline ? (
+          <View className="rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3">
+            <Text className="text-xs text-amber-200">
+              Search and custom entry currently need a network connection.
+            </Text>
+          </View>
+        ) : null}
+
+        {notice ? (
+          <View className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3">
+            <Text className="text-xs text-emerald-200">{notice}</Text>
+          </View>
+        ) : null}
+
+        {error ? (
+          <View className="rounded-xl border border-danger-red/50 bg-danger-red/10 px-4 py-3">
+            <Text className="text-xs text-danger-red">{error}</Text>
+          </View>
+        ) : null}
+
+        {mode === "search" ? (
+          <View className="gap-4">
+            <Card className="gap-3">
+              <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+                Search Query
+              </Text>
+              <TextInput
+                style={styles.input}
+                placeholder="Search by figure name, character, or line"
+                placeholderTextColor="#64748b"
+                value={query}
+                onChangeText={setQuery}
+                autoCorrect={false}
+                autoCapitalize="words"
+              />
+              <Text className="text-xs text-secondary-text">
+                Results update as you type.
+              </Text>
+            </Card>
+
+            {trimmedQuery.length === 0 ? (
+              <Card>
+                <Text className="text-sm text-secondary-text">
+                  Enter a search term to find a catalog figure.
+                </Text>
+              </Card>
+            ) : searchQuery.isLoading ? (
+              <Card>
+                <Text className="text-sm text-secondary-text">Searching catalog...</Text>
+              </Card>
+            ) : searchResults.length === 0 ? (
+              <Card className="gap-3">
+                <Text className="text-sm text-secondary-text">
+                  No catalog matches found for "{trimmedQuery}".
+                </Text>
+                <Button
+                  label="Create Custom Entry"
+                  variant="secondary"
+                  onPress={() => setMode("custom")}
+                />
+              </Card>
+            ) : (
+              searchResults.map((item) => {
+                const key = item.id;
+                const busy = pendingId === key;
+                return (
+                  <Card key={item.id} className="gap-3">
+                    <View>
+                      <Text className="text-base font-space-semibold text-frost-text">
+                        {item.name}
+                      </Text>
+                      <Text className="mt-1 text-xs text-secondary-text">
+                        {item.series ?? "Unknown series"}
+                      </Text>
+                    </View>
+                    <View className="gap-2">
+                      {STATUS_OPTIONS.map((option) => (
+                        <Button
+                          key={option.value}
+                          label={option.label}
+                          variant={option.value === "OWNED" ? "primary" : "secondary"}
+                          loading={busy}
+                          disabled={busy}
+                          onPress={() => {
+                            track("manual_search_add_selected", {
+                              status: option.value,
+                            });
+                            void createOrUpdateFigure(
+                              {
+                                figureId: item.id,
+                                name: item.name,
+                                series: item.series ?? null,
+                              },
+                              option.value
+                            );
+                          }}
+                        />
+                      ))}
+                    </View>
+                  </Card>
+                );
+              })
+            )}
+          </View>
+        ) : (
+          <View className="gap-4">
+            <Card className="gap-3">
+              <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+                Figure Name
+              </Text>
+              <TextInput
+                style={styles.input}
+                placeholder="Commander Cody"
+                placeholderTextColor="#64748b"
+                value={customName}
+                onChangeText={setCustomName}
+                autoCapitalize="words"
+              />
+              <Text className="text-xs font-space-semibold uppercase tracking-widest text-secondary-text">
+                Series
+              </Text>
+              <TextInput
+                style={styles.input}
+                placeholder="Custom line or collection"
+                placeholderTextColor="#64748b"
+                value={customSeries}
+                onChangeText={setCustomSeries}
+                autoCapitalize="words"
+              />
+            </Card>
+
+            <Card className="gap-2">
+              {STATUS_OPTIONS.map((option) => (
+                <Button
+                  key={option.value}
+                  label={option.label}
+                  variant={option.value === "OWNED" ? "primary" : "secondary"}
+                  loading={pendingId === customName.trim()}
+                  disabled={!customPayload || pendingId === customName.trim()}
+                  onPress={() => {
+                    if (!customPayload) {
+                      setError("Enter a figure name first.");
+                      return;
+                    }
+                    track("custom_entry_add_selected", { status: option.value });
+                    void createOrUpdateFigure(
+                      {
+                        name: customPayload.name as string,
+                        series:
+                          typeof customPayload.series === "string"
+                            ? customPayload.series
+                            : null,
+                        customPayload,
+                      },
+                      option.value
+                    );
+                  }}
+                />
+              ))}
+            </Card>
+          </View>
+        )}
+      </ScrollView>
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  content: {
+    padding: 16,
+    paddingBottom: 40,
+    gap: 16,
+  },
+  input: {
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "#22324d",
+    backgroundColor: "#101a2a",
+    color: "#f8fafc",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 14,
+  },
+});

--- a/apps/mobile/app/(tabs)/wishlist/details.tsx
+++ b/apps/mobile/app/(tabs)/wishlist/details.tsx
@@ -21,7 +21,11 @@ import { useOfflineStatus } from "../../../src/offline/OfflineProvider";
 import { useFigureByFigureId, useFigureById } from "../../../src/offline/hooks";
 import { track } from "../../../src/observability";
 import { cx } from "../../../src/utils/cx";
-import { useSavePriceAlert, useUserFigurePrice } from "../../../src/api/price";
+import {
+  usePriceAlerts,
+  useSavePriceAlert,
+  useUserFigurePrice,
+} from "../../../src/api/price";
 
 const RETAILER_LABELS: Record<Retailer, string> = {
   AMAZON: "Amazon",
@@ -50,9 +54,15 @@ function formatDateTime(value?: string | null) {
 function getLatestChecked(listings: RetailerListing[]) {
   if (!listings.length) return null;
   return listings.reduce<string | null>((latest, listing) => {
-    if (!latest) return listing.last_checked_at;
-    return Date.parse(listing.last_checked_at) > Date.parse(latest)
-      ? listing.last_checked_at
+    const checkedAt = listing.last_checked_at ?? null;
+    if (!checkedAt) {
+      return latest;
+    }
+    if (!latest) {
+      return checkedAt;
+    }
+    return Date.parse(checkedAt) > Date.parse(latest)
+      ? checkedAt
       : latest;
   }, null);
 }
@@ -80,6 +90,7 @@ export default function WishlistDetailsScreen() {
   const figureId = userFigure?.figureId ?? params.figureId ?? null;
 
   const priceQuery = useUserFigurePrice(userFigureId);
+  const priceAlertsQuery = usePriceAlerts(userFigureId);
   const saveAlert = useSavePriceAlert();
 
   const [alertId, setAlertId] = useState<string | null>(null);
@@ -111,6 +122,17 @@ export default function WishlistDetailsScreen() {
         : ""
     );
   }, [userFigure?.id]);
+
+  useEffect(() => {
+    const alert = priceAlertsQuery.data?.items?.[0];
+    if (!alert) {
+      return;
+    }
+    setAlertId(alert.id);
+    setAlertTargetPrice(alert.target_price.toFixed(2));
+    setAlertRetailers(alert.retailers.length ? alert.retailers : ["AMAZON", "TARGET"]);
+    setAlertNotifyRestock(alert.notify_on_restock);
+  }, [priceAlertsQuery.data?.items]);
 
   const listings = priceQuery.data?.listings ?? [];
   const history = priceQuery.data?.history ?? [];

--- a/apps/mobile/src/api/figures.ts
+++ b/apps/mobile/src/api/figures.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { FigureSchema } from "@force-collector/shared";
+import {
+  FigureListResponseSchema,
+  FigureSchema,
+} from "@force-collector/shared";
 import { apiRequest } from "./client";
 import { env } from "../env";
 import { queryKeys } from "./queryKeys";
@@ -31,16 +34,33 @@ type LoreState = {
   error: string | null;
 };
 
+export function useFigureSearch(query: string) {
+  const trimmedQuery = query.trim();
+  return useQuery({
+    queryKey: queryKeys.catalog(trimmedQuery),
+    enabled: Boolean(env.API_BASE_URL && trimmedQuery),
+    queryFn: () =>
+      apiRequest({
+        path: `/v1/figures?query=${encodeURIComponent(trimmedQuery)}&limit=25`,
+        schema: FigureListResponseSchema,
+        auth: "required",
+      }),
+  });
+}
+
+export async function fetchFigureById(figureId: string) {
+  return apiRequest({
+    path: `/v1/figures/${figureId}`,
+    schema: FigureSchema,
+    auth: "required",
+  });
+}
+
 export function useFigure(figureId?: string | null) {
   return useQuery({
     queryKey: queryKeys.figure(figureId ?? "unknown"),
     enabled: Boolean(env.API_BASE_URL && figureId),
-    queryFn: () =>
-      apiRequest({
-        path: `/v1/figures/${figureId}`,
-        schema: FigureSchema,
-        auth: "required",
-      }),
+    queryFn: () => fetchFigureById(figureId as string),
   });
 }
 

--- a/apps/mobile/src/api/price.ts
+++ b/apps/mobile/src/api/price.ts
@@ -1,10 +1,10 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   PriceAlertCreateRequestSchema,
+  PriceAlertListResponseSchema,
   PriceAlertSchema,
   PriceAlertUpdateRequestSchema,
   PriceResponseSchema,
-  type PriceAlert,
   type PriceAlertCreateRequest,
   type PriceAlertUpdateRequest,
 } from "@force-collector/shared";
@@ -61,9 +61,24 @@ async function updatePriceAlert(id: string, payload: PriceAlertUpdateRequest) {
   });
 }
 
+export function usePriceAlerts(userFigureId?: string | null) {
+  return useQuery({
+    queryKey: [...queryKeys.priceAlerts(), userFigureId ?? "unknown"],
+    enabled: Boolean(env.API_BASE_URL && userFigureId),
+    queryFn: () =>
+      apiRequest({
+        path: `/v1/price-alerts?user_figure_id=${encodeURIComponent(
+          userFigureId as string
+        )}`,
+        schema: PriceAlertListResponseSchema,
+        auth: "required",
+      }),
+  });
+}
+
 export function useSavePriceAlert() {
   return useMutation({
-    mutationFn: async ({ id, payload }: SavePriceAlertInput): Promise<PriceAlert> => {
+    mutationFn: async ({ id, payload }: SavePriceAlertInput) => {
       if (id) {
         return updatePriceAlert(id, payload as PriceAlertUpdateRequest);
       }

--- a/apps/mobile/src/api/scan.ts
+++ b/apps/mobile/src/api/scan.ts
@@ -17,7 +17,7 @@ export function useScanLookup() {
         method: "POST",
         body: parsed.data,
         schema: ScanLookupResponseSchema,
-        auth: "optional",
+        auth: "required",
       });
     },
   });

--- a/apps/mobile/src/api/user-figures.ts
+++ b/apps/mobile/src/api/user-figures.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  HydratedUserFigureListResponseSchema,
   UserFigureConditionSchema,
   UserFigureStatusSchema,
   type UserFigureStatus,
@@ -7,11 +8,15 @@ import {
 import { apiRequest } from "./client";
 
 const UserFigureCreatePayloadSchema = z.object({
-  figure_id: z.string().uuid(),
+  figure_id: z.string().uuid().optional(),
   status: UserFigureStatusSchema,
   condition: UserFigureConditionSchema.optional(),
   user_id: z.string().uuid().optional(),
-});
+  custom_figure_payload: z.record(z.unknown()).optional(),
+}).refine(
+  (value) => Boolean(value.figure_id || value.custom_figure_payload),
+  "figure_id or custom_figure_payload is required."
+);
 
 const UserFigureUpdatePayloadSchema = z.object({
   status: UserFigureStatusSchema,
@@ -30,32 +35,33 @@ const UserFigureCreateResponseSchema = z.object({
   id: z.string(),
   figure_id: z.string().optional().nullable(),
   status: UserFigureStatusSchema.optional(),
-  condition: UserFigureConditionSchema.optional(),
-  purchase_price: z.number().optional(),
-  purchase_currency: z.string().optional(),
-  purchase_date: z.string().optional(),
-  notes: z.string().optional(),
-  photo_refs: z.array(z.string()).optional(),
+  condition: UserFigureConditionSchema.optional().nullable(),
+  purchase_price: z.number().optional().nullable(),
+  purchase_currency: z.string().optional().nullable(),
+  purchase_date: z.string().optional().nullable(),
+  notes: z.string().optional().nullable(),
+  photo_refs: z.array(z.string()).optional().nullable(),
   updated_at: z.string().datetime().optional(),
 });
 
 const UserFigureUpdateResponseSchema = z.object({
   id: z.string(),
   status: UserFigureStatusSchema.optional(),
-  condition: UserFigureConditionSchema.optional(),
-  purchase_price: z.number().optional(),
-  purchase_currency: z.string().optional(),
-  purchase_date: z.string().optional(),
-  notes: z.string().optional(),
-  photo_refs: z.array(z.string()).optional(),
+  condition: UserFigureConditionSchema.optional().nullable(),
+  purchase_price: z.number().optional().nullable(),
+  purchase_currency: z.string().optional().nullable(),
+  purchase_date: z.string().optional().nullable(),
+  notes: z.string().optional().nullable(),
+  photo_refs: z.array(z.string()).optional().nullable(),
   updated_at: z.string().datetime().optional(),
 });
 
 export async function createUserFigure(payload: {
-  figure_id: string;
+  figure_id?: string;
   status: UserFigureStatus;
   condition?: z.infer<typeof UserFigureConditionSchema>;
   user_id?: string;
+  custom_figure_payload?: Record<string, unknown>;
 }) {
   const parsed = UserFigureCreatePayloadSchema.safeParse(payload);
   if (!parsed.success) {
@@ -66,6 +72,20 @@ export async function createUserFigure(payload: {
     method: "POST",
     body: parsed.data,
     schema: UserFigureCreateResponseSchema,
+    auth: "required",
+  });
+}
+
+export async function fetchHydratedUserFigures(status?: UserFigureStatus) {
+  const params = new URLSearchParams();
+  params.set("limit", "500");
+  if (status) {
+    params.set("status", status);
+  }
+
+  return apiRequest({
+    path: `/v1/user-figures?${params.toString()}`,
+    schema: HydratedUserFigureListResponseSchema,
     auth: "required",
   });
 }

--- a/apps/mobile/src/offline/OfflineProvider.tsx
+++ b/apps/mobile/src/offline/OfflineProvider.tsx
@@ -1,6 +1,8 @@
 import NetInfo from "@react-native-community/netinfo";
 import React, { createContext, useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "../auth/AuthProvider";
+import { fetchHydratedUserFigures } from "../api/user-figures";
+import { replaceHydratedFigures } from "./cache";
 import { getDatabase } from "./db";
 import { syncPendingMutations } from "./sync";
 
@@ -18,6 +20,40 @@ export function OfflineProvider({ children }: { children: React.ReactNode }) {
   const { status, user } = useAuth();
   const [isOnline, setIsOnline] = useState(true);
   const [ready, setReady] = useState(false);
+
+  const hydrateFromServer = useCallback(async () => {
+    if (status !== "signedIn" || !user?.id || !isOnline) {
+      return;
+    }
+
+    const response = await fetchHydratedUserFigures();
+    const records = response.items.map((item) => ({
+      id: item.id,
+      figureId: item.figure_id ?? null,
+      name:
+        item.figure?.name ??
+        (typeof item.custom_figure_payload?.name === "string"
+          ? item.custom_figure_payload.name
+          : "Custom figure"),
+      series:
+        item.figure?.series ??
+        (typeof item.custom_figure_payload?.series === "string"
+          ? item.custom_figure_payload.series
+          : null),
+      status: item.status,
+      lastPrice: item.listing_summary?.last_price ?? null,
+      inStock: item.listing_summary?.in_stock ?? null,
+      condition: item.condition,
+      purchasePrice: item.purchase_price ?? null,
+      purchaseCurrency: item.purchase_currency ?? null,
+      purchaseDate: item.purchase_date ?? null,
+      notes: item.notes ?? null,
+      photoRefs: item.photo_refs ?? null,
+      updatedAt: item.updated_at,
+    }));
+
+    await replaceHydratedFigures(records);
+  }, [isOnline, status, user?.id]);
 
   useEffect(() => {
     if (status === "checking") {
@@ -49,20 +85,32 @@ export function OfflineProvider({ children }: { children: React.ReactNode }) {
       );
       setIsOnline(online);
       if (online) {
-        syncPendingMutations().catch(() => undefined);
+        syncPendingMutations()
+          .then(() => hydrateFromServer())
+          .catch(() => undefined);
       }
     });
 
     return () => unsubscribe();
-  }, []);
+  }, [hydrateFromServer]);
+
+  useEffect(() => {
+    if (status !== "signedIn" || !user?.id || !isOnline) {
+      return;
+    }
+
+    hydrateFromServer().catch(() => undefined);
+  }, [hydrateFromServer, isOnline, status, user?.id]);
 
   const syncNow = useCallback(async () => {
     if (!isOnline) {
       return { synced: 0, skipped: true };
     }
 
-    return syncPendingMutations();
-  }, [isOnline]);
+    const result = await syncPendingMutations();
+    await hydrateFromServer();
+    return result;
+  }, [hydrateFromServer, isOnline]);
 
   const value = useMemo(
     () => ({

--- a/apps/mobile/src/offline/cache.ts
+++ b/apps/mobile/src/offline/cache.ts
@@ -214,6 +214,8 @@ type UpsertFigureInput = {
   syncPending?: boolean;
 };
 
+type ReplaceFigureInput = Omit<UpsertFigureInput, "syncPending">;
+
 export async function upsertFigureRecord({
   id,
   figureId = null,
@@ -258,6 +260,65 @@ export async function upsertFigureRecord({
   const updated = await getFigureById(id);
   notifyFigureChanges();
   return updated;
+}
+
+export async function replaceHydratedFigures(records: ReplaceFigureInput[]) {
+  const db = await getDatabase();
+  const pendingRows = await db.getAllAsync<{ id: string }>(
+    "SELECT id FROM figures WHERE sync_pending = 1"
+  );
+  const pendingIds = new Set(pendingRows.map((row) => row.id));
+  const persistedIds = records
+    .map((record) => record.id)
+    .filter((id) => !pendingIds.has(id));
+
+  await db.execAsync("BEGIN TRANSACTION;");
+  try {
+    if (persistedIds.length) {
+      const placeholders = persistedIds.map(() => "?").join(", ");
+      await db.runAsync(
+        `DELETE FROM figures WHERE sync_pending = 0 AND id NOT IN (${placeholders})`,
+        persistedIds
+      );
+    } else {
+      await db.runAsync("DELETE FROM figures WHERE sync_pending = 0");
+    }
+
+    for (const record of records) {
+      if (pendingIds.has(record.id)) {
+        continue;
+      }
+      const resolvedPhotoRefs =
+        record.photoRefs && Array.isArray(record.photoRefs)
+          ? JSON.stringify(record.photoRefs)
+          : null;
+      await db.runAsync(
+        "INSERT OR REPLACE INTO figures (id, figure_id, name, series, status, last_price, in_stock, condition, purchase_price, purchase_currency, purchase_date, notes, photo_refs, updated_at, sync_pending) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)",
+        [
+          record.id,
+          record.figureId ?? null,
+          record.name,
+          record.series,
+          record.status,
+          record.lastPrice ?? null,
+          record.inStock === null ? null : record.inStock ? 1 : 0,
+          record.condition ?? null,
+          record.purchasePrice ?? null,
+          record.purchaseCurrency ?? null,
+          record.purchaseDate ?? null,
+          record.notes ?? null,
+          resolvedPhotoRefs,
+          record.updatedAt ?? new Date().toISOString(),
+        ]
+      );
+    }
+    await db.execAsync("COMMIT;");
+  } catch (error) {
+    await db.execAsync("ROLLBACK;");
+    throw error;
+  }
+
+  notifyFigureChanges();
 }
 
 export async function replaceFigureIdentity(

--- a/apps/mobile/src/offline/db.ts
+++ b/apps/mobile/src/offline/db.ts
@@ -29,7 +29,6 @@ export async function getDatabase() {
     dbPromise = SQLite.openDatabaseAsync(resolveDbName());
     const db = await dbPromise;
     await migrate(db);
-    await seedIfEmpty(db);
   }
 
   return dbPromise;
@@ -105,88 +104,5 @@ async function migrate(db: SQLite.SQLiteDatabase) {
     await db.execAsync("ALTER TABLE figures ADD COLUMN photo_refs TEXT;");
   } catch {
     // Column already exists.
-  }
-}
-
-async function seedIfEmpty(db: SQLite.SQLiteDatabase) {
-  const row = await db.getFirstAsync<{ count: number }>(
-    "SELECT COUNT(*) as count FROM figures"
-  );
-  if (row && row.count > 0) {
-    return;
-  }
-
-  const now = new Date().toISOString();
-  await db.execAsync("BEGIN TRANSACTION;");
-  try {
-    await db.runAsync(
-      "INSERT INTO figures (id, name, series, status, last_price, in_stock, updated_at, sync_pending) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-      [
-        "fc-seed-1",
-        "Ahsoka Tano",
-        "The Clone Wars",
-        "OWNED",
-        34.99,
-        1,
-        now,
-        0,
-      ]
-    );
-    await db.runAsync(
-      "INSERT INTO figures (id, name, series, status, last_price, in_stock, updated_at, sync_pending) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-      [
-        "fc-seed-2",
-        "Darth Vader",
-        "Original Trilogy",
-        "OWNED",
-        29.99,
-        1,
-        now,
-        0,
-      ]
-    );
-    await db.runAsync(
-      "INSERT INTO figures (id, name, series, status, last_price, in_stock, updated_at, sync_pending) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-      [
-        "fc-seed-3",
-        "The Mandalorian",
-        "The Mandalorian",
-        "OWNED",
-        32.5,
-        0,
-        now,
-        0,
-      ]
-    );
-    await db.runAsync(
-      "INSERT INTO figures (id, name, series, status, last_price, in_stock, updated_at, sync_pending) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-      [
-        "fc-seed-4",
-        "Bo-Katan Kryze",
-        "The Mandalorian",
-        "WISHLIST",
-        27.0,
-        1,
-        now,
-        0,
-      ]
-    );
-    await db.runAsync(
-      "INSERT INTO figures (id, name, series, status, last_price, in_stock, updated_at, sync_pending) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-      [
-        "fc-seed-5",
-        "Captain Rex",
-        "The Clone Wars",
-        "WISHLIST",
-        36.0,
-        0,
-        now,
-        0,
-      ]
-    );
-    await db.execAsync("COMMIT;");
-  } catch (error) {
-    await db.execAsync("ROLLBACK;");
-    throw error;
   }
 }

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "allowImportingTsExtensions": true,
     "types": ["expo-router/types", "nativewind/types"],
     "baseUrl": ".",
     "paths": {

--- a/docs/mobile-data-flow.md
+++ b/docs/mobile-data-flow.md
@@ -1,0 +1,31 @@
+# Mobile Data Flow
+
+This repo now uses the following ownership model for mobile data:
+
+- Auth/session: Supabase Auth client in the mobile app.
+- Server truth for catalog, pricing, goals, profile, and scan lookup: Supabase edge API in `supabase/functions/api`.
+- Device cache for collection/wishlist rendering and offline mutations: SQLite in `apps/mobile/src/offline`.
+- Asset storage: Supabase Storage for user photos.
+
+## Read Path
+
+1. The app signs in with Supabase Auth.
+2. `OfflineProvider` hydrates the local SQLite cache from `GET /v1/user-figures`.
+3. Collection, wishlist, and home screens render from the local cache.
+4. Catalog search, analytics, goals, pricing, and scan lookup read from the edge API.
+
+## Write Path
+
+1. Online mutations go through the edge API when a server endpoint exists.
+2. Local cache is updated immediately for responsive UI.
+3. Offline-capable collection mutations are queued in SQLite and replayed through the edge API when connectivity returns.
+
+## Direct Supabase Client Access
+
+Direct client-side Supabase calls should be limited to:
+
+- Auth operations
+- Storage uploads/downloads for user photos
+- Profile/data export-import flows that do not yet have API wrappers
+
+All collection, catalog, pricing, and scan/database reads should prefer the edge API so shared response normalization and auth rules stay in one place.

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -11,7 +11,14 @@ import {
   UserFigureSchema,
   UserProfileSchema,
   UserSchema,
-} from "./entities";
+} from "./entities.ts";
+
+export const ListingSummarySchema = z.object({
+  last_price: z.number().nullable().optional(),
+  in_stock: z.boolean().nullable().optional(),
+  last_checked_at: z.string().datetime().nullable().optional(),
+});
+export type ListingSummary = z.infer<typeof ListingSummarySchema>;
 
 export const ApiSuccessSchema = z.object({
   success: z.boolean(),
@@ -92,6 +99,25 @@ export const UserFigureListResponseSchema = z.object({
   next_cursor: z.string().nullable().optional(),
 });
 export type UserFigureListResponse = z.infer<typeof UserFigureListResponseSchema>;
+
+export const HydratedUserFigureSchema = UserFigureSchema.extend({
+  figure: FigureSchema.nullable().optional(),
+  listing_summary: ListingSummarySchema.nullable().optional(),
+});
+export type HydratedUserFigure = z.infer<typeof HydratedUserFigureSchema>;
+
+export const HydratedUserFigureListResponseSchema = z.object({
+  items: z.array(HydratedUserFigureSchema),
+  next_cursor: z.string().nullable().optional(),
+});
+export type HydratedUserFigureListResponse = z.infer<
+  typeof HydratedUserFigureListResponseSchema
+>;
+
+export const PriceAlertListResponseSchema = z.object({
+  items: z.array(PriceAlertSchema),
+});
+export type PriceAlertListResponse = z.infer<typeof PriceAlertListResponseSchema>;
 
 export const UserFigureCreateRequestSchema = UserFigureSchema.omit({
   id: true,

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -1,5 +1,15 @@
 import { z } from "zod";
 
+const FiniteNumberSchema = z.coerce.number().refine(Number.isFinite, {
+  message: "Expected a finite number.",
+});
+
+const IntegerSchema = z.coerce.number().int();
+
+const NullableFiniteNumberSchema = z.union([z.null(), FiniteNumberSchema]);
+
+const NullableIntegerSchema = z.union([z.null(), IntegerSchema]);
+
 export const AllegianceThemeSchema = z.enum(["LIGHT", "DARK"]);
 export type AllegianceTheme = z.infer<typeof AllegianceThemeSchema>;
 
@@ -31,29 +41,29 @@ export const UserProfileSchema = z.object({
 export type UserProfile = z.infer<typeof UserProfileSchema>;
 
 export const EraSchema = z.enum([
-  "Prequel",
-  "Original",
-  "Sequel",
+  "PREQUEL",
+  "ORIGINAL",
+  "SEQUEL",
   "TV",
-  "Gaming",
-  "Other",
+  "GAMING",
+  "OTHER",
 ]);
 export type Era = z.infer<typeof EraSchema>;
 
 export const FigureSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
-  subtitle: z.string().optional(),
-  edition: z.string().optional(),
-  series: z.string(),
-  wave: z.union([z.string(), z.number()]),
-  release_year: z.number().int(),
-  era: EraSchema,
-  faction: z.string(),
-  exclusivity: z.string(),
-  upc: z.string().optional(),
-  primary_image_url: z.string().url().optional(),
-  lore: z.string().optional(),
+  subtitle: z.string().nullable().optional(),
+  edition: z.string().nullable().optional(),
+  series: z.string().nullable().optional(),
+  wave: z.union([z.string(), z.number()]).nullable().optional(),
+  release_year: NullableIntegerSchema.optional(),
+  era: EraSchema.nullable().optional(),
+  faction: z.string().nullable().optional(),
+  exclusivity: z.string().nullable().optional(),
+  upc: z.string().nullable().optional(),
+  primary_image_url: z.string().url().nullable().optional(),
+  lore: z.string().nullable().optional(),
   specs: z.record(z.unknown()).optional(),
   created_at: z.string().datetime(),
   updated_at: z.string().datetime(),
@@ -80,17 +90,18 @@ export const UserFigureSchema = z.object({
   id: z.string().uuid(),
   user_id: z.string().uuid(),
   figure_id: z.string().uuid().nullable(),
-  custom_figure_payload: z.record(z.unknown()).optional(),
+  custom_figure_payload: z.record(z.unknown()).nullable().optional(),
   status: UserFigureStatusSchema,
   condition: UserFigureConditionSchema,
-  purchase_price: z.number().optional(),
-  purchase_currency: z.string().optional(),
+  purchase_price: NullableFiniteNumberSchema.optional(),
+  purchase_currency: z.string().nullable().optional(),
   purchase_date: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .nullable()
     .optional(),
-  notes: z.string().optional(),
-  photo_refs: z.array(z.string()).optional(),
+  notes: z.string().nullable().optional(),
+  photo_refs: z.array(z.string()).nullable().optional(),
   created_at: z.string().datetime(),
   updated_at: z.string().datetime(),
 });
@@ -110,10 +121,10 @@ export const RetailerListingSchema = z.object({
   figure_id: z.string().uuid(),
   retailer: RetailerSchema,
   product_url: z.string().url(),
-  external_id: z.string().optional(),
-  last_checked_at: z.string().datetime(),
+  external_id: z.string().nullable().optional(),
+  last_checked_at: z.string().datetime().nullable().optional(),
   in_stock: z.boolean().nullable(),
-  current_price: z.number().nullable(),
+  current_price: NullableFiniteNumberSchema,
   currency: z.string(),
 });
 export type RetailerListing = z.infer<typeof RetailerListingSchema>;
@@ -121,7 +132,7 @@ export type RetailerListing = z.infer<typeof RetailerListingSchema>;
 export const PriceHistoryPointSchema = z.object({
   id: z.string().uuid(),
   retailer_listing_id: z.string().uuid(),
-  price: z.number(),
+  price: FiniteNumberSchema,
   currency: z.string(),
   in_stock: z.boolean().nullable(),
   captured_at: z.string().datetime(),
@@ -132,12 +143,12 @@ export const PriceAlertSchema = z.object({
   id: z.string().uuid(),
   user_id: z.string().uuid(),
   user_figure_id: z.string().uuid(),
-  target_price: z.number(),
+  target_price: FiniteNumberSchema,
   currency: z.string(),
   enabled: z.boolean(),
   retailers: z.array(RetailerSchema),
   notify_on_restock: z.boolean(),
-  cooldown_hours: z.number().int(),
+  cooldown_hours: IntegerSchema,
 });
 export type PriceAlert = z.infer<typeof PriceAlertSchema>;
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./entities";
-export * from "./api";
+export * from "./entities.ts";
+export * from "./api.ts";

--- a/supabase/functions/api/index.ts
+++ b/supabase/functions/api/index.ts
@@ -36,8 +36,11 @@ const FIGURE_LORE_FIELDS =
   "id,name,subtitle,edition,lore,lore_updated_at,lore_source";
 const USER_FIGURE_SELECT_FIELDS =
   "id,user_id,figure_id,custom_figure_payload,status,condition,purchase_price,purchase_currency,purchase_date,notes,photo_refs,created_at,updated_at";
+const PRICE_ALERT_SELECT_FIELDS =
+  "id,user_id,user_figure_id,target_price,currency,enabled,retailers,notify_on_restock,cooldown_hours";
 const USER_FIGURE_STATUSES = ["OWNED", "WISHLIST", "PREORDER", "SOLD"] as const;
 const USER_FIGURE_CONDITIONS = ["MINT", "OPENED", "LOOSE", "UNKNOWN"] as const;
+const RETAILER_KINDS = ["EBAY", "AMAZON", "TARGET", "WALMART", "OTHER"] as const;
 const GOAL_PROGRESS_RULES = ["OWNED_COUNT"] as const;
 const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 const ACHIEVEMENT_KEY_ORDER = [
@@ -728,6 +731,10 @@ function isUserFigureCondition(
   return typeof value === "string" && USER_FIGURE_CONDITIONS.includes(value as any);
 }
 
+function isRetailerKind(value: unknown): value is (typeof RETAILER_KINDS)[number] {
+  return typeof value === "string" && RETAILER_KINDS.includes(value as any);
+}
+
 function parseNumeric(value: unknown) {
   if (value === null || value === undefined) {
     return { ok: true, value: null as number | null };
@@ -742,6 +749,24 @@ function parseNumeric(value: unknown) {
     }
   }
   return { ok: false, value: null as number | null };
+}
+
+function normalizeFigure(row: Record<string, unknown> | null) {
+  if (!row) {
+    return row;
+  }
+
+  const normalized = { ...row } as Record<string, unknown>;
+  if (typeof normalized.release_year === "string") {
+    const parsed = Number(normalized.release_year);
+    if (Number.isInteger(parsed)) {
+      normalized.release_year = parsed;
+    }
+  }
+  if (normalized.specs === null) {
+    normalized.specs = {};
+  }
+  return normalized;
 }
 
 function normalizeUserFigure(row: Record<string, unknown> | null) {
@@ -776,6 +801,60 @@ function normalizeUserFigure(row: Record<string, unknown> | null) {
     );
   } else if (normalized.photo_refs === null) {
     delete normalized.photo_refs;
+  }
+  return normalized;
+}
+
+function normalizeRetailerListing(row: Record<string, unknown> | null) {
+  if (!row) {
+    return row;
+  }
+
+  const normalized = { ...row } as Record<string, unknown>;
+  if (typeof normalized.current_price === "string") {
+    const parsed = Number(normalized.current_price);
+    if (Number.isFinite(parsed)) {
+      normalized.current_price = parsed;
+    }
+  }
+  return normalized;
+}
+
+function normalizePriceHistoryPoint(row: Record<string, unknown> | null) {
+  if (!row) {
+    return row;
+  }
+
+  const normalized = { ...row } as Record<string, unknown>;
+  if (typeof normalized.price === "string") {
+    const parsed = Number(normalized.price);
+    if (Number.isFinite(parsed)) {
+      normalized.price = parsed;
+    }
+  }
+  return normalized;
+}
+
+function normalizePriceAlert(row: Record<string, unknown> | null) {
+  if (!row) {
+    return row;
+  }
+
+  const normalized = { ...row } as Record<string, unknown>;
+  if (typeof normalized.target_price === "string") {
+    const parsed = Number(normalized.target_price);
+    if (Number.isFinite(parsed)) {
+      normalized.target_price = parsed;
+    }
+  }
+  if (typeof normalized.cooldown_hours === "string") {
+    const parsed = Number(normalized.cooldown_hours);
+    if (Number.isInteger(parsed)) {
+      normalized.cooldown_hours = parsed;
+    }
+  }
+  if (!Array.isArray(normalized.retailers)) {
+    normalized.retailers = [];
   }
   return normalized;
 }
@@ -1212,6 +1291,54 @@ async function fetchPriceHistory(
   }[];
 }
 
+function buildListingSummary(
+  listings: Array<Record<string, unknown>>
+): {
+  last_price: number | null;
+  in_stock: boolean | null;
+  last_checked_at: string | null;
+} | null {
+  if (!listings.length) {
+    return null;
+  }
+
+  let lastCheckedAt: string | null = null;
+  let inStock: boolean | null = null;
+  let lastPrice: number | null = null;
+  let fallbackPrice: number | null = null;
+
+  for (const listing of listings) {
+    const checkedAt =
+      typeof listing.last_checked_at === "string" ? listing.last_checked_at : null;
+    const price = toNumber(listing.current_price);
+    const listingInStock =
+      typeof listing.in_stock === "boolean" ? listing.in_stock : null;
+
+    if (price !== null && fallbackPrice === null) {
+      fallbackPrice = price;
+    }
+
+    if (
+      checkedAt &&
+      (!lastCheckedAt || Date.parse(checkedAt) > Date.parse(lastCheckedAt))
+    ) {
+      lastCheckedAt = checkedAt;
+      inStock = listingInStock;
+      lastPrice = price;
+    }
+  }
+
+  if (lastPrice === null) {
+    lastPrice = fallbackPrice;
+  }
+
+  return {
+    last_price: lastPrice,
+    in_stock: inStock,
+    last_checked_at: lastCheckedAt,
+  };
+}
+
 serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
@@ -1568,7 +1695,10 @@ serve(async (req) => {
       return jsonResponse({ message: error.message }, 500);
     }
 
-    return jsonResponse({ items: data ?? [], next_cursor: null });
+    return jsonResponse({
+      items: (data ?? []).map((row) => normalizeFigure(row as Record<string, unknown>)),
+      next_cursor: null,
+    });
   }
 
   if (path.startsWith("/v1/figures/") && req.method === "GET") {
@@ -1605,7 +1735,7 @@ serve(async (req) => {
       if (!data) {
         return jsonResponse({ message: "Figure not found." }, 404);
       }
-      return jsonResponse(data);
+      return jsonResponse(normalizeFigure(data as Record<string, unknown>));
     }
 
     const refreshParam = url.searchParams.get("refresh");
@@ -1698,7 +1828,7 @@ serve(async (req) => {
 
     const limitParam = Number(url.searchParams.get("limit") || 50);
     const limit = Number.isFinite(limitParam)
-      ? Math.min(Math.max(limitParam, 1), 100)
+      ? Math.min(Math.max(limitParam, 1), 500)
       : 50;
 
     const query = url.searchParams.get("query")?.trim();
@@ -1741,7 +1871,65 @@ serve(async (req) => {
     const items = (data ?? []).map((row) =>
       normalizeUserFigure(row as Record<string, unknown>)
     );
-    return jsonResponse({ items, next_cursor: null });
+
+    const figureIds = [
+      ...new Set(
+        items
+          .map((row) =>
+            typeof row?.figure_id === "string" ? (row.figure_id as string) : null
+          )
+          .filter(Boolean) as string[]
+      ),
+    ];
+
+    let figuresById = new Map<string, Record<string, unknown>>();
+    if (figureIds.length) {
+      const { data: figures, error: figuresError } = await supabase
+        .from("figures")
+        .select(FIGURE_SELECT_FIELDS)
+        .in("id", figureIds);
+      if (figuresError) {
+        return jsonResponse({ message: figuresError.message }, 500);
+      }
+      figuresById = new Map(
+        (figures ?? []).map((figure) => [
+          String(figure.id),
+          normalizeFigure(figure as Record<string, unknown>) as Record<string, unknown>,
+        ])
+      );
+    }
+
+    let listingsByFigureId = new Map<string, Array<Record<string, unknown>>>();
+    if (figureIds.length) {
+      const { data: listings, error: listingsError } = await supabase
+        .from("retailer_listings")
+        .select("figure_id,current_price,in_stock,last_checked_at")
+        .in("figure_id", figureIds);
+      if (listingsError) {
+        return jsonResponse({ message: listingsError.message }, 500);
+      }
+      for (const listing of listings ?? []) {
+        const figureId = String(listing.figure_id);
+        const bucket = listingsByFigureId.get(figureId) ?? [];
+        bucket.push(listing as Record<string, unknown>);
+        listingsByFigureId.set(figureId, bucket);
+      }
+    }
+
+    return jsonResponse({
+      items: items.map((item) => {
+        const figureId =
+          typeof item?.figure_id === "string" ? (item.figure_id as string) : null;
+        return {
+          ...item,
+          figure: figureId ? figuresById.get(figureId) ?? null : null,
+          listing_summary: figureId
+            ? buildListingSummary(listingsByFigureId.get(figureId) ?? [])
+            : null,
+        };
+      }),
+      next_cursor: null,
+    });
   }
 
   if (path === "/v1/user-figures" && req.method === "POST") {
@@ -2085,6 +2273,323 @@ serve(async (req) => {
       .from("user_figures")
       .delete()
       .eq("id", userFigureId)
+      .eq("user_id", user.id);
+    if (error) {
+      return jsonResponse({ message: error.message }, 500);
+    }
+
+    return jsonResponse({ success: true });
+  }
+
+  if (path.startsWith("/v1/user-figures/") && req.method === "GET") {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return jsonResponse({ message: "Supabase env not configured." }, 500);
+    }
+
+    const authHeader = req.headers.get("authorization") ?? "";
+    const supabase = createAuthedClient(supabaseUrl, supabaseAnonKey, authHeader);
+    const { user, error: authError } = await requireUser(supabase);
+    if (authError || !user) {
+      return jsonResponse({ message: "Unauthorized." }, 401);
+    }
+
+    const segments = path.split("/").filter(Boolean);
+    const userFigureId = segments[2];
+    const subresource = segments[3];
+    if (subresource !== "price") {
+      return jsonResponse({ message: "Not found." }, 404);
+    }
+    if (!userFigureId) {
+      return jsonResponse({ message: "User figure id is required." }, 400);
+    }
+
+    const { data: userFigure, error: userFigureError } = await supabase
+      .from("user_figures")
+      .select("id,figure_id")
+      .eq("id", userFigureId)
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (userFigureError) {
+      return jsonResponse({ message: userFigureError.message }, 500);
+    }
+    if (!userFigure) {
+      return jsonResponse({ message: "User figure not found." }, 404);
+    }
+    if (!userFigure.figure_id) {
+      return jsonResponse({ listings: [], history: [] });
+    }
+
+    const { data: listings, error: listingsError } = await supabase
+      .from("retailer_listings")
+      .select("*")
+      .eq("figure_id", userFigure.figure_id)
+      .order("current_price", { ascending: true, nullsFirst: false });
+    if (listingsError) {
+      return jsonResponse({ message: listingsError.message }, 500);
+    }
+
+    const listingIds = (listings ?? []).map((listing) => String(listing.id));
+    let history: Array<Record<string, unknown>> = [];
+    if (listingIds.length) {
+      const { data: historyRows, error: historyError } = await supabase
+        .from("price_history_points")
+        .select("id,retailer_listing_id,price,currency,in_stock,captured_at")
+        .in("retailer_listing_id", listingIds)
+        .order("captured_at", { ascending: true });
+      if (historyError) {
+        return jsonResponse({ message: historyError.message }, 500);
+      }
+      history = (historyRows ?? []).map((row) =>
+        normalizePriceHistoryPoint(row as Record<string, unknown>) as Record<string, unknown>
+      );
+    }
+
+    return jsonResponse({
+      listings: (listings ?? []).map((row) =>
+        normalizeRetailerListing(row as Record<string, unknown>)
+      ),
+      history,
+    });
+  }
+
+  if (path === "/v1/price-alerts" && req.method === "GET") {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return jsonResponse({ message: "Supabase env not configured." }, 500);
+    }
+
+    const authHeader = req.headers.get("authorization") ?? "";
+    const supabase = createAuthedClient(supabaseUrl, supabaseAnonKey, authHeader);
+    const { user, error: authError } = await requireUser(supabase);
+    if (authError || !user) {
+      return jsonResponse({ message: "Unauthorized." }, 401);
+    }
+
+    let query = supabase
+      .from("price_alerts")
+      .select(PRICE_ALERT_SELECT_FIELDS)
+      .eq("user_id", user.id)
+      .order("id", { ascending: true });
+
+    const userFigureId = url.searchParams.get("user_figure_id");
+    if (userFigureId) {
+      query = query.eq("user_figure_id", userFigureId);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      return jsonResponse({ message: error.message }, 500);
+    }
+
+    return jsonResponse({
+      items: (data ?? []).map((row) =>
+        normalizePriceAlert(row as Record<string, unknown>)
+      ),
+    });
+  }
+
+  if (path === "/v1/price-alerts" && req.method === "POST") {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return jsonResponse({ message: "Supabase env not configured." }, 500);
+    }
+
+    const authHeader = req.headers.get("authorization") ?? "";
+    const supabase = createAuthedClient(supabaseUrl, supabaseAnonKey, authHeader);
+    const { user, error: authError } = await requireUser(supabase);
+    if (authError || !user) {
+      return jsonResponse({ message: "Unauthorized." }, 401);
+    }
+
+    let payload: Record<string, unknown> | null = null;
+    try {
+      payload = await req.json();
+    } catch {
+      return jsonResponse({ message: "Invalid JSON body." }, 400);
+    }
+    if (!payload || Array.isArray(payload)) {
+      return jsonResponse({ message: "Invalid JSON body." }, 400);
+    }
+
+    const targetPrice = parseNumeric(payload.target_price);
+    if (!targetPrice.ok || targetPrice.value === null || targetPrice.value <= 0) {
+      return jsonResponse({ message: "Invalid target_price." }, 400);
+    }
+    if (typeof payload.user_figure_id !== "string") {
+      return jsonResponse({ message: "user_figure_id is required." }, 400);
+    }
+    if (typeof payload.currency !== "string" || !payload.currency.trim()) {
+      return jsonResponse({ message: "currency is required." }, 400);
+    }
+
+    const { data: userFigure, error: userFigureError } = await supabase
+      .from("user_figures")
+      .select("id")
+      .eq("id", payload.user_figure_id)
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (userFigureError) {
+      return jsonResponse({ message: userFigureError.message }, 500);
+    }
+    if (!userFigure) {
+      return jsonResponse({ message: "User figure not found." }, 404);
+    }
+
+    const retailers = Array.isArray(payload.retailers)
+      ? payload.retailers.filter((value) => isRetailerKind(value))
+      : [];
+
+    const record = {
+      user_id: user.id,
+      user_figure_id: payload.user_figure_id,
+      target_price: targetPrice.value,
+      currency: payload.currency.trim().toUpperCase(),
+      enabled: payload.enabled !== false,
+      retailers,
+      notify_on_restock: payload.notify_on_restock !== false,
+      cooldown_hours:
+        typeof payload.cooldown_hours === "number" && payload.cooldown_hours > 0
+          ? Math.trunc(payload.cooldown_hours)
+          : 24,
+    };
+
+    const { data, error } = await supabase
+      .from("price_alerts")
+      .insert(record)
+      .select(PRICE_ALERT_SELECT_FIELDS)
+      .maybeSingle();
+    if (error) {
+      return jsonResponse({ message: error.message }, 500);
+    }
+
+    return jsonResponse(normalizePriceAlert(data as Record<string, unknown>));
+  }
+
+  if (path.startsWith("/v1/price-alerts/") && req.method === "PATCH") {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return jsonResponse({ message: "Supabase env not configured." }, 500);
+    }
+
+    const authHeader = req.headers.get("authorization") ?? "";
+    const supabase = createAuthedClient(supabaseUrl, supabaseAnonKey, authHeader);
+    const { user, error: authError } = await requireUser(supabase);
+    if (authError || !user) {
+      return jsonResponse({ message: "Unauthorized." }, 401);
+    }
+
+    const segments = path.split("/").filter(Boolean);
+    const alertId = segments[2];
+    if (!alertId) {
+      return jsonResponse({ message: "Price alert id is required." }, 400);
+    }
+
+    let payload: Record<string, unknown> | null = null;
+    try {
+      payload = await req.json();
+    } catch {
+      return jsonResponse({ message: "Invalid JSON body." }, 400);
+    }
+    if (!payload || Array.isArray(payload)) {
+      return jsonResponse({ message: "Invalid JSON body." }, 400);
+    }
+
+    const updates: Record<string, unknown> = {};
+    if ("target_price" in payload) {
+      const targetPrice = parseNumeric(payload.target_price);
+      if (!targetPrice.ok || targetPrice.value === null || targetPrice.value <= 0) {
+        return jsonResponse({ message: "Invalid target_price." }, 400);
+      }
+      updates.target_price = targetPrice.value;
+    }
+    if ("currency" in payload) {
+      if (typeof payload.currency !== "string" || !payload.currency.trim()) {
+        return jsonResponse({ message: "Invalid currency." }, 400);
+      }
+      updates.currency = payload.currency.trim().toUpperCase();
+    }
+    if ("enabled" in payload) {
+      if (typeof payload.enabled !== "boolean") {
+        return jsonResponse({ message: "Invalid enabled." }, 400);
+      }
+      updates.enabled = payload.enabled;
+    }
+    if ("notify_on_restock" in payload) {
+      if (typeof payload.notify_on_restock !== "boolean") {
+        return jsonResponse({ message: "Invalid notify_on_restock." }, 400);
+      }
+      updates.notify_on_restock = payload.notify_on_restock;
+    }
+    if ("cooldown_hours" in payload) {
+      if (
+        typeof payload.cooldown_hours !== "number" ||
+        !Number.isFinite(payload.cooldown_hours) ||
+        payload.cooldown_hours <= 0
+      ) {
+        return jsonResponse({ message: "Invalid cooldown_hours." }, 400);
+      }
+      updates.cooldown_hours = Math.trunc(payload.cooldown_hours);
+    }
+    if ("retailers" in payload) {
+      if (
+        !Array.isArray(payload.retailers) ||
+        payload.retailers.some((value) => !isRetailerKind(value))
+      ) {
+        return jsonResponse({ message: "Invalid retailers." }, 400);
+      }
+      updates.retailers = payload.retailers;
+    }
+
+    if (!Object.keys(updates).length) {
+      return jsonResponse({ message: "No valid fields to update." }, 400);
+    }
+
+    const { data, error } = await supabase
+      .from("price_alerts")
+      .update(updates)
+      .eq("id", alertId)
+      .eq("user_id", user.id)
+      .select(PRICE_ALERT_SELECT_FIELDS)
+      .maybeSingle();
+    if (error) {
+      return jsonResponse({ message: error.message }, 500);
+    }
+    if (!data) {
+      return jsonResponse({ message: "Price alert not found." }, 404);
+    }
+
+    return jsonResponse(normalizePriceAlert(data as Record<string, unknown>));
+  }
+
+  if (path.startsWith("/v1/price-alerts/") && req.method === "DELETE") {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return jsonResponse({ message: "Supabase env not configured." }, 500);
+    }
+
+    const authHeader = req.headers.get("authorization") ?? "";
+    const supabase = createAuthedClient(supabaseUrl, supabaseAnonKey, authHeader);
+    const { user, error: authError } = await requireUser(supabase);
+    if (authError || !user) {
+      return jsonResponse({ message: "Unauthorized." }, 401);
+    }
+
+    const segments = path.split("/").filter(Boolean);
+    const alertId = segments[2];
+    if (!alertId) {
+      return jsonResponse({ message: "Price alert id is required." }, 400);
+    }
+
+    const { error } = await supabase
+      .from("price_alerts")
+      .delete()
+      .eq("id", alertId)
       .eq("user_id", user.id);
     if (error) {
       return jsonResponse({ message: error.message }, 500);
@@ -2548,11 +3053,19 @@ serve(async (req) => {
 
   if (path === "/v1/scan/lookup" && req.method === "POST") {
     const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
     const supabaseKey =
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ||
       Deno.env.get("SUPABASE_ANON_KEY");
-    if (!supabaseUrl || !supabaseKey) {
+    if (!supabaseUrl || !supabaseAnonKey || !supabaseKey) {
       return jsonResponse({ message: "Supabase env not configured." }, 500);
+    }
+
+    const authHeader = req.headers.get("authorization") ?? "";
+    const authClient = createAuthedClient(supabaseUrl, supabaseAnonKey, authHeader);
+    const { user, error: authError } = await requireUser(authClient);
+    if (authError || !user) {
+      return jsonResponse({ message: "Unauthorized." }, 401);
     }
 
     let payload: { barcode?: string; symbology?: string; locale?: string } | null = null;

--- a/tests/contracts/api-contracts.test.mjs
+++ b/tests/contracts/api-contracts.test.mjs
@@ -1,0 +1,167 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  FigureSchema,
+  PriceAlertSchema,
+  PriceHistoryPointSchema,
+  RetailerListingSchema,
+} from "../../packages/shared/src/entities.ts";
+import {
+  HydratedUserFigureListResponseSchema,
+  PriceAlertListResponseSchema,
+  PriceResponseSchema,
+} from "../../packages/shared/src/api.ts";
+
+test("FigureSchema accepts nullable backend-style figure payloads", () => {
+  const result = FigureSchema.safeParse({
+    id: "00000000-0000-4000-8000-000000000001",
+    name: "Darth Vader",
+    subtitle: "Archive",
+    edition: null,
+    series: "The Black Series",
+    wave: null,
+    release_year: 2020,
+    era: "ORIGINAL",
+    faction: "Empire",
+    exclusivity: "General",
+    upc: "630509989138",
+    primary_image_url: null,
+    lore: null,
+    specs: {},
+    created_at: "2026-03-01T00:00:00.000Z",
+    updated_at: "2026-03-01T00:00:00.000Z",
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("RetailerListingSchema coerces numeric strings and nullable timestamps", () => {
+  const result = RetailerListingSchema.safeParse({
+    id: "00000000-0000-4000-8000-000000000002",
+    figure_id: "00000000-0000-4000-8000-000000000001",
+    retailer: "AMAZON",
+    product_url: "https://example.com/listing",
+    external_id: null,
+    last_checked_at: null,
+    in_stock: true,
+    current_price: "24.99",
+    currency: "USD",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.success && result.data.current_price, 24.99);
+});
+
+test("PriceResponseSchema accepts normalized pricing payloads", () => {
+  const result = PriceResponseSchema.safeParse({
+    listings: [
+      {
+        id: "00000000-0000-4000-8000-000000000003",
+        figure_id: "00000000-0000-4000-8000-000000000001",
+        retailer: "EBAY",
+        product_url: "https://example.com/ebay",
+        external_id: "123",
+        last_checked_at: "2026-03-01T00:00:00.000Z",
+        in_stock: false,
+        current_price: "31.50",
+        currency: "USD",
+      },
+    ],
+    history: [
+      {
+        id: "00000000-0000-4000-8000-000000000004",
+        retailer_listing_id: "00000000-0000-4000-8000-000000000003",
+        price: "31.50",
+        currency: "USD",
+        in_stock: false,
+        captured_at: "2026-03-01T00:00:00.000Z",
+      },
+    ],
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.success && result.data.history[0].price, 31.5);
+});
+
+test("Hydrated user figure list accepts nested figure and listing summary payloads", () => {
+  const result = HydratedUserFigureListResponseSchema.safeParse({
+    items: [
+      {
+        id: "00000000-0000-4000-8000-000000000005",
+        user_id: "00000000-0000-4000-8000-000000000006",
+        figure_id: "00000000-0000-4000-8000-000000000001",
+        custom_figure_payload: null,
+        status: "OWNED",
+        condition: "UNKNOWN",
+        purchase_price: null,
+        purchase_currency: null,
+        purchase_date: null,
+        notes: null,
+        photo_refs: null,
+        created_at: "2026-03-01T00:00:00.000Z",
+        updated_at: "2026-03-01T00:00:00.000Z",
+        figure: {
+          id: "00000000-0000-4000-8000-000000000001",
+          name: "Darth Vader",
+          subtitle: null,
+          edition: null,
+          series: "The Black Series",
+          wave: null,
+          release_year: 2020,
+          era: "ORIGINAL",
+          faction: "Empire",
+          exclusivity: "General",
+          upc: null,
+          primary_image_url: null,
+          lore: null,
+          specs: {},
+          created_at: "2026-03-01T00:00:00.000Z",
+          updated_at: "2026-03-01T00:00:00.000Z",
+        },
+        listing_summary: {
+          last_price: 24.99,
+          in_stock: true,
+          last_checked_at: "2026-03-01T00:00:00.000Z",
+        },
+      },
+    ],
+    next_cursor: null,
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("Price alert schemas accept numeric strings from PostgREST", () => {
+  const alert = {
+    id: "00000000-0000-4000-8000-000000000007",
+    user_id: "00000000-0000-4000-8000-000000000006",
+    user_figure_id: "00000000-0000-4000-8000-000000000005",
+    target_price: "19.99",
+    currency: "USD",
+    enabled: true,
+    retailers: ["AMAZON", "TARGET"],
+    notify_on_restock: true,
+    cooldown_hours: "24",
+  };
+
+  const itemResult = PriceAlertSchema.safeParse(alert);
+  const listResult = PriceAlertListResponseSchema.safeParse({ items: [alert] });
+
+  assert.equal(itemResult.success, true);
+  assert.equal(listResult.success, true);
+  assert.equal(itemResult.success && itemResult.data.target_price, 19.99);
+});
+
+test("PriceHistoryPointSchema rejects non-numeric price values", () => {
+  const result = PriceHistoryPointSchema.safeParse({
+    id: "00000000-0000-4000-8000-000000000008",
+    retailer_listing_id: "00000000-0000-4000-8000-000000000003",
+    price: "not-a-number",
+    currency: "USD",
+    in_stock: true,
+    captured_at: "2026-03-01T00:00:00.000Z",
+  });
+
+  assert.equal(result.success, false);
+});


### PR DESCRIPTION
## Summary
This PR fixes a group of runtime and product-flow issues that were all rooted in the same problem: the mobile app, shared schemas, local cache, and edge API had drifted into different data models and incomplete flows.

On the user side, that showed up as several visible failures. Figure and retailer responses could validate incorrectly even when the backend returned success. Wishlist pricing and price-alert setup called routes that did not exist. Fresh users could see seeded demo data instead of their actual collection because the local SQLite cache was treated like a source of truth without a real hydration path. Manual search and custom entry were also exposed in the UI but routed to a placeholder screen.

## Root Cause
The underlying issue was fragmented ownership of data across four layers:

- shared Zod contracts that did not reflect actual backend nullability and numeric serialization
- a Supabase edge API that normalized some resources but left key routes missing
- a mobile cache seeded with demo content and not reliably hydrated from server truth
- UI flows that were designed against intended APIs rather than implemented ones

Because these layers were not aligned, TypeScript could still pass while users hit runtime validation failures, 404s, or dead-end navigation.

## Fix
This PR addresses the problem in three grouped commits:

1. `fix shared api contracts`
The shared schemas now accept the real payload shapes coming back from PostgREST and the edge API, including nullable catalog fields and numeric-string coercion where appropriate. I also added lightweight contract tests so those payload assumptions are checked directly.

2. `add pricing routes and cache hydration`
The edge API now implements the missing pricing and price-alert routes, returns hydrated user-figure payloads for mobile cache sync, and requires authentication for scan lookup before privileged/provider-backed work happens. On mobile, the offline layer no longer seeds demo records and instead hydrates local state from real user figures after auth and sync.

3. `implement manual entry flows`
The placeholder manual search route has been replaced with a working screen that supports catalog search and custom entry creation. The add-figure modal now routes correctly into those flows, and wishlist details can load and edit existing price alerts.

## Validation
I validated the changes with:

- `node --test tests/contracts/api-contracts.test.mjs`
- `npx tsc --noEmit` from `apps/mobile`

I did not include a passing `expo-doctor` run in this PR because it did not produce usable output in the sandboxed environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Manual figure entry with search and custom entry modes
  * Price alerts management for tracking price changes
  * Figure search functionality
  * Enhanced offline support with automatic server synchronization

* **Improvements**
  * Better handling of price and listing data
  * Improved user figure details management

* **Documentation**
  * Added comprehensive mobile data flow guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->